### PR TITLE
Add write permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Grant write access to contents in the release workflow to enable necessary operations during the release process.