### PR TITLE
bugs: add default join role functionality and channel permissions

### DIFF
--- a/apps/desktop/src/components/channel/ChannelView.tsx
+++ b/apps/desktop/src/components/channel/ChannelView.tsx
@@ -12,6 +12,7 @@ import { MessageInput } from "./MessageInput";
 import { TypingIndicator } from "./TypingIndicator";
 import { DropZone } from "./DropZone";
 import type { PendingAttachment } from "./FileAttachmentButton";
+import { useCanSendInChannel, useIsAdmin } from "../../hooks/usePermissions";
 
 // Stable empty object to avoid new references on each render
 const EMPTY_REACTIONS: Record<string, Record<string, ReactionData[]>> = {};
@@ -38,6 +39,10 @@ export function ChannelView({
   const transport = useTransport();
   const publicKey = useIdentityStore((s) => s.publicKey);
   const typingTimeoutsRef = useRef<Map<string, number>>(new Map());
+
+  const canSend = useCanSendInChannel(channelId);
+  const isAdmin = useIsAdmin();
+  const showInput = canSend || isAdmin;
 
   const [droppedAttachments, setDroppedAttachments] = useState<PendingAttachment[]>([]);
   
@@ -274,11 +279,20 @@ export function ChannelView({
           onRemoveReaction={handleRemoveReaction}
         />
         <TypingIndicator channelId={channelId} />
-        <MessageInput
-          channelId={channelId}
-          channelName={channelName}
-          externalAttachments={droppedAttachments}
-        />
+        {showInput ? (
+          <MessageInput
+            channelId={channelId}
+            channelName={channelName}
+            externalAttachments={droppedAttachments}
+          />
+        ) : (
+          <div className="px-4 py-3 mx-4 mb-4 rounded-lg bg-nodes-surface border border-nodes-border flex items-center gap-2 text-nodes-text-muted text-sm">
+            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            You don't have permission to send messages in <strong className="text-nodes-text">#{channelName}</strong>.
+          </div>
+        )}
       </div>
     </DropZone>
   );

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { useDisplayName, clearDisplayNameCache } from "./useDisplayName";
 export { useDisplayNames } from "./useDisplayNames";
 export { useNodeSubscriptions } from "./useNodeSubscriptions";
 export { useMemberSubscription } from "./useMemberSubscription";
+export { useChannelSubscription } from "./useChannelSubscription";
 export { useRoleSubscriptions } from "./useRoleSubscriptions";
 export { useAvatar } from "./useAvatar";
 export { useVoiceChannelParticipants } from "./useVoiceChannelParticipants";

--- a/apps/desktop/src/hooks/useChannelSubscription.ts
+++ b/apps/desktop/src/hooks/useChannelSubscription.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from "react";
+import { NodeManager } from "@nodes/transport-gun";
+import { useNodeStore } from "../stores/node-store";
+import { useIdentityStore } from "../stores/identity-store";
+
+const nodeManager = new NodeManager();
+
+// Refresh interval for polling channel changes
+const CHANNEL_POLL_INTERVAL = 4_000; // 4 seconds
+
+/**
+ * Hook that polls for channel list changes for the active Node.
+ * Detects channel additions and deletions and updates the node store.
+ * Uses the same polling approach as useMemberSubscription for Gun compatibility.
+ */
+export function useChannelSubscription() {
+  const isAuthenticated = useIdentityStore((s) => s.isAuthenticated);
+  const publicKey = useIdentityStore((s) => s.publicKey);
+  const activeNodeId = useNodeStore((s) => s.activeNodeId);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    // Clear any existing interval
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (!isAuthenticated || !publicKey || !activeNodeId) return;
+
+    const pollChannels = async () => {
+      try {
+        const freshChannels = await nodeManager.getChannels(activeNodeId);
+        const state = useNodeStore.getState();
+        const currentChannels = state.channels[activeNodeId] || [];
+
+        const freshIds = new Set(freshChannels.map((c) => c.id));
+        const currentIds = new Set(currentChannels.map((c) => c.id));
+
+        const hasNewChannels = freshChannels.some((c) => !currentIds.has(c.id));
+        const hasRemovedChannels = currentChannels.some((c) => !freshIds.has(c.id));
+        const hasUpdatedChannels = freshChannels.some((fresh) => {
+          const current = currentChannels.find((c) => c.id === fresh.id);
+          if (!current) return false;
+          return (
+            current.name !== fresh.name ||
+            current.topic !== fresh.topic ||
+            current.position !== fresh.position ||
+            current.slowMode !== fresh.slowMode
+          );
+        });
+
+        if (!hasNewChannels && !hasRemovedChannels && !hasUpdatedChannels) return;
+
+        useNodeStore.setState((s) => {
+          const activeChannelId = s.activeChannelId;
+
+          // If active channel was deleted, clear it
+          const newActiveChannelId =
+            activeChannelId && freshIds.has(activeChannelId)
+              ? activeChannelId
+              : freshChannels.length > 0
+              ? freshChannels[0].id
+              : null;
+
+          return {
+            channels: { ...s.channels, [activeNodeId]: freshChannels },
+            activeChannelId: newActiveChannelId,
+          };
+        });
+      } catch {
+        // Silent fail
+      }
+    };
+
+    // Start polling
+    intervalRef.current = setInterval(pollChannels, CHANNEL_POLL_INTERVAL);
+
+    // Immediate poll after a short delay
+    const initialPoll = setTimeout(pollChannels, 1500);
+
+    return () => {
+      clearTimeout(initialPoll);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [isAuthenticated, publicKey, activeNodeId]);
+}

--- a/apps/desktop/src/hooks/useNodeDeletionGuard.ts
+++ b/apps/desktop/src/hooks/useNodeDeletionGuard.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import { NodeManager } from "@nodes/transport-gun";
+import { useNodeStore } from "../stores/node-store";
+import { useThemeStore } from "../stores/theme-store";
+import { useIdentityStore } from "../stores/identity-store";
+
+const nodeManager = new NodeManager();
+
+/**
+ * Watches every node in the store for deletion or theme changes by subscribing
+ * to each node's Gun metadata.
+ *
+ * - Deletion: auto-removes the node from local state for all online members.
+ * - Theme change: re-applies the node theme live if it's the active node,
+ *   so other members see theme updates without needing to reload.
+ */
+export function useNodeDeletionGuard() {
+  const isAuthenticated = useIdentityStore((s) => s.isAuthenticated);
+  const nodes = useNodeStore((s) => s.nodes);
+  // Map of nodeId → unsubscribe fn for currently watched nodes
+  const unsubsRef = useRef<Map<string, () => void>>(new Map());
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      unsubsRef.current.forEach((unsub) => unsub());
+      unsubsRef.current.clear();
+      return;
+    }
+
+    const watchedIds = new Set(unsubsRef.current.keys());
+    const currentIds = new Set(nodes.map((n) => n.id));
+
+    // Subscribe to nodes that aren't yet being watched
+    for (const node of nodes) {
+      if (watchedIds.has(node.id)) continue;
+
+      const unsub = nodeManager.subscribeToNodeMeta(
+        node.id,
+        // onDeleted
+        () => {
+          const stillPresent = useNodeStore.getState().nodes.some((n) => n.id === node.id);
+          if (stillPresent) {
+            useNodeStore.getState().removeNodeFromState(node.id);
+          }
+        },
+        // onThemeChange — fires for OTHER clients when the owner saves a new theme
+        (theme) => {
+          const activeNodeId = useNodeStore.getState().activeNodeId;
+          if (activeNodeId !== node.id) return; // not viewing this node
+          const themeStore = useThemeStore.getState();
+          if (theme) {
+            themeStore.applyNodeTheme(theme);
+          } else {
+            themeStore.clearNodeTheme();
+          }
+        }
+      );
+
+      unsubsRef.current.set(node.id, unsub);
+    }
+
+    // Unsubscribe from nodes that were removed from state (user left/was kicked)
+    for (const [nodeId, unsub] of unsubsRef.current) {
+      if (!currentIds.has(nodeId)) {
+        unsub();
+        unsubsRef.current.delete(nodeId);
+      }
+    }
+  }, [isAuthenticated, nodes]);
+
+  // Clean up all subscriptions on unmount
+  useEffect(() => {
+    return () => {
+      unsubsRef.current.forEach((unsub) => unsub());
+      unsubsRef.current.clear();
+    };
+  }, []);
+}

--- a/apps/desktop/src/layouts/AppShell.tsx
+++ b/apps/desktop/src/layouts/AppShell.tsx
@@ -8,6 +8,8 @@ import { useVoiceStore } from "../stores/voice-store";
 import { useSearchStore } from "../stores/search-store";
 import { useNodeSubscriptions } from "../hooks/useNodeSubscriptions";
 import { useMemberSubscription } from "../hooks/useMemberSubscription";
+import { useChannelSubscription } from "../hooks/useChannelSubscription";
+import { useNodeDeletionGuard } from "../hooks/useNodeDeletionGuard";
 import { useRoleSubscriptions } from "../hooks/useRoleSubscriptions";
 import { useDMSubscriptions } from "../hooks/useDMSubscriptions";
 import { usePresenceSubscriptions } from "../hooks/usePresenceSubscriptions";
@@ -121,8 +123,14 @@ export function AppShell() {
   // Subscribe to member changes for the active Node
   useMemberSubscription();
 
+  // Subscribe to channel list changes for the active Node (detects deletions/additions)
+  useChannelSubscription();
+
   // Subscribe to roles for the active Node
   useRoleSubscriptions();
+
+  // Watch all joined nodes for deletion and auto-remove them from state
+  useNodeDeletionGuard();
 
   // Subscribe to kick/ban events for the current user
   useModerationEvents();

--- a/apps/desktop/src/stores/theme-store.ts
+++ b/apps/desktop/src/stores/theme-store.ts
@@ -49,6 +49,12 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
       settings: { ...state.settings, activeThemeId: themeId },
     }));
     
+    // Don't override node theme — it will be cleared when leaving the node
+    if (get().nodeThemeOverride) {
+      get().saveToStorage();
+      return;
+    }
+
     // Apply the theme
     const theme = get().allThemes.find((t) => t.id === themeId) ?? BUILT_IN_THEMES[0];
     ThemeEngine.apply(theme, get().settings.accentColorOverride);
@@ -60,6 +66,12 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
       settings: { ...state.settings, accentColorOverride: color },
     }));
     
+    // Don't override node theme — it will be cleared when leaving the node
+    if (get().nodeThemeOverride) {
+      get().saveToStorage();
+      return;
+    }
+
     // Apply the accent
     const theme = get().getActiveTheme();
     ThemeEngine.apply(theme, color);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export interface NodeServer {
   createdAt: number;
   inviteKey: string; // Random key for invite link verification
   theme?: NodesTheme | null; // Custom Node theme (applies to all members by default)
+  defaultRoleId?: string; // Role ID assigned to new members when they join (defaults to MEMBER)
 }
 
 export interface NodeMember {
@@ -208,6 +209,9 @@ export interface RolePermissions {
   manageRoles: boolean;          // Create, edit, delete roles
   assignRoles: boolean;          // Assign roles to members
 
+  // Channel visibility
+  viewChannel: boolean;          // See and read a channel (can be overridden per-channel)
+
   // Messaging
   sendMessages: boolean;
   sendFiles: boolean;
@@ -242,6 +246,7 @@ export const DEFAULT_PERMISSIONS: Record<BuiltInRoleId, RolePermissions> = {
   [BUILT_IN_ROLE_IDS.OWNER]: {
     manageNode: true, manageChannels: true, editChannelSettings: true,
     manageRoles: true, assignRoles: true,
+    viewChannel: true,
     sendMessages: true, sendFiles: true, useReactions: true, embedLinks: true,
     editOwnMessages: true, deleteOwnMessages: true, deleteAnyMessage: true,
     kickMembers: true, banMembers: true, manageInvites: true, viewAuditLog: true,
@@ -250,6 +255,7 @@ export const DEFAULT_PERMISSIONS: Record<BuiltInRoleId, RolePermissions> = {
   [BUILT_IN_ROLE_IDS.ADMIN]: {
     manageNode: true, manageChannels: true, editChannelSettings: true,
     manageRoles: true, assignRoles: true,
+    viewChannel: true,
     sendMessages: true, sendFiles: true, useReactions: true, embedLinks: true,
     editOwnMessages: true, deleteOwnMessages: true, deleteAnyMessage: true,
     kickMembers: true, banMembers: true, manageInvites: true, viewAuditLog: true,
@@ -258,6 +264,7 @@ export const DEFAULT_PERMISSIONS: Record<BuiltInRoleId, RolePermissions> = {
   [BUILT_IN_ROLE_IDS.MODERATOR]: {
     manageNode: false, manageChannels: false, editChannelSettings: true,
     manageRoles: false, assignRoles: false,
+    viewChannel: true,
     sendMessages: true, sendFiles: true, useReactions: true, embedLinks: true,
     editOwnMessages: true, deleteOwnMessages: true, deleteAnyMessage: true,
     kickMembers: true, banMembers: false, manageInvites: false, viewAuditLog: true,
@@ -266,6 +273,7 @@ export const DEFAULT_PERMISSIONS: Record<BuiltInRoleId, RolePermissions> = {
   [BUILT_IN_ROLE_IDS.MEMBER]: {
     manageNode: false, manageChannels: false, editChannelSettings: false,
     manageRoles: false, assignRoles: false,
+    viewChannel: true,
     sendMessages: true, sendFiles: true, useReactions: true, embedLinks: true,
     editOwnMessages: true, deleteOwnMessages: true, deleteAnyMessage: false,
     kickMembers: false, banMembers: false, manageInvites: false, viewAuditLog: false,

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -63,9 +63,14 @@ export class PermissionResolver {
       if (role?.permissions[permission]) return true;
     }
 
-    // Implicit member role check (everyone has member permissions by default)
-    const memberRole = this.roles.get(BUILT_IN_ROLE_IDS.MEMBER);
-    if (memberRole?.permissions[permission]) return true;
+    // Implicit member role fallback — ONLY when the user has no explicitly assigned
+    // roles (e.g. a freshly joined user whose member record hasn't propagated yet).
+    // If the user has roles, those roles are authoritative; the fallback must not
+    // silently override a restrictive role like "visitor".
+    if (userRoleIds.length === 0) {
+      const memberRole = this.roles.get(BUILT_IN_ROLE_IDS.MEMBER);
+      if (memberRole?.permissions[permission]) return true;
+    }
 
     return false;
   }
@@ -142,6 +147,7 @@ export class PermissionResolver {
     const keys: (keyof RolePermissions)[] = [
       "manageNode", "manageChannels", "editChannelSettings",
       "manageRoles", "assignRoles",
+      "viewChannel",
       "sendMessages", "sendFiles", "useReactions", "embedLinks",
       "editOwnMessages", "deleteOwnMessages", "deleteAnyMessage",
       "kickMembers", "banMembers", "manageInvites", "viewAuditLog",

--- a/packages/transport-gun/src/role-manager.ts
+++ b/packages/transport-gun/src/role-manager.ts
@@ -72,9 +72,13 @@ export class RoleManager {
 
         let permissions: RolePermissions;
         try {
-          permissions = typeof data.permissions === "string"
+          const parsed = typeof data.permissions === "string"
             ? JSON.parse(data.permissions)
             : data.permissions;
+          // Backfill any permission fields added after this role was stored in Gun
+          const builtInId = data.id as keyof typeof DEFAULT_PERMISSIONS;
+          const defaults = DEFAULT_PERMISSIONS[builtInId] ?? DEFAULT_PERMISSIONS[BUILT_IN_ROLE_IDS.MEMBER];
+          permissions = { ...defaults, ...parsed };
         } catch {
           // Fallback to default permissions for this role type
           const builtInId = data.id as keyof typeof DEFAULT_PERMISSIONS;
@@ -120,9 +124,13 @@ export class RoleManager {
 
         let permissions: RolePermissions;
         try {
-          permissions = typeof data.permissions === "string"
+          const parsed = typeof data.permissions === "string"
             ? JSON.parse(data.permissions)
             : data.permissions;
+          // Backfill any permission fields added after this role was stored in Gun
+          const builtInId = data.id as keyof typeof DEFAULT_PERMISSIONS;
+          const defaults = DEFAULT_PERMISSIONS[builtInId] ?? DEFAULT_PERMISSIONS[BUILT_IN_ROLE_IDS.MEMBER];
+          permissions = { ...defaults, ...parsed };
         } catch {
           const builtInId = data.id as keyof typeof DEFAULT_PERMISSIONS;
           permissions = DEFAULT_PERMISSIONS[builtInId] || DEFAULT_PERMISSIONS[BUILT_IN_ROLE_IDS.MEMBER];


### PR DESCRIPTION
- Implemented default join role selection in RolesTab component, allowing admins to set a default role for new members.
- Added useCanViewChannel and useCanSendInChannel hooks to manage channel visibility and message sending permissions based on user roles.
- Enhanced useMemberSubscription to handle role updates for members.
- Introduced useChannelSubscription to poll for channel changes and update the node store accordingly.
- Added useNodeDeletionGuard to monitor node deletions and theme changes, ensuring live updates for active nodes.
- Updated NodeManager to support defaultRoleId and handle channel permission overrides.
- Modified role permissions to include viewChannel and adjusted permission resolution logic for better role management.