### PR TITLE
Enable NSIS updater for Tauri application in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,5 @@ jobs:
           prerelease: true
           projectPath: apps/desktop
           tauriScript: pnpm tauri
+          updaterJsonPreferNsis: true
           args: ${{ matrix.args }}


### PR DESCRIPTION
Configure the release workflow to enable the NSIS updater for the Tauri application.