### PR TITLE
Update pubkey in Tauri configuration for security compliance

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -68,7 +68,7 @@
         "https://github.com/Leveq/Nodes/releases/latest/download/latest.json"
       ],
       "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg0NEYyRTBFMzMzREVBOTAKUldTUTZqMHpEaTVQaFByMnd1U0xaWlhVY0hiTDE0NmJLbXh1UlRSY2d2NzFKZ3ZlVzNKSkJ1RnkK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU1RkExNjJEQjJFRTNEN0IKUldSN1BlNnlMUmI2NVo0cE0yamlaRDhQVVVSaEtqRDF3TlNzYUhjWnFudytYS2MxenNYaDFOak8K"
     }
   }
 }


### PR DESCRIPTION
Replace the public key in the Tauri configuration to meet updated security standards.