### PR TITLE
Change prerelease status to false in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           releaseName: 'Nodes ${{ github.ref_name }}'
           releaseBody: 'See release notes.'
           releaseDraft: true
-          prerelease: true
+          prerelease: false
           projectPath: apps/desktop
           tauriScript: pnpm tauri
           updaterJsonPreferNsis: true


### PR DESCRIPTION
Update the release workflow to set the prerelease status to false, ensuring that releases are marked as stable.