### PR TITLE
Change prerelease status to true in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           releaseName: 'Nodes ${{ github.ref_name }}'
           releaseBody: 'See release notes.'
           releaseDraft: true
-          prerelease: false
+          prerelease: true
           projectPath: apps/desktop
           tauriScript: pnpm tauri
           updaterJsonPreferNsis: true


### PR DESCRIPTION
Update the release workflow to set the prerelease status to true, allowing for proper handling of pre-release versions.