### PR TITLE
Update deploy script to use pnpm exec for build command

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -11,7 +11,7 @@ VITE_IPFS_API_URL=https://nodesipfs.leveq.dev \
 VITE_GUN_RELAY_URL=wss://nodesrelay.leveq.dev/gun \
 VITE_LIVEKIT_URL=wss://nodesvoice.leveq.dev \
 VITE_LIVEKIT_API_KEY=nodes-stg-key \
-pnpm build
+pnpm exec vite build
 
 echo "📦 Uploading to staging server..."
 cd ../..


### PR DESCRIPTION
Change the build command in the deploy script to utilize `pnpm exec vite build` for improved execution.