### PR TITLE
Implement node delisting on deletion and improve cleanup process

### DIFF
--- a/apps/desktop/src/stores/node-store.ts
+++ b/apps/desktop/src/stores/node-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { NodeManager, roleManager } from "@nodes/transport-gun";
+import { NodeManager, roleManager, directoryManager } from "@nodes/transport-gun";
 import type { NodeServer, NodeMember, NodeChannel } from "@nodes/core";
 import { useToastStore } from "./toast-store";
 import { useNotificationStore } from "./notification-store";
@@ -196,6 +196,10 @@ export const useNodeStore = create<NodeState>((set, get) => ({
   deleteNode: async (nodeId) => {
     try {
       const node = get().nodes.find((n) => n.id === nodeId);
+      
+      // Delist from directory first (if listed)
+      await directoryManager.delistNode(nodeId).catch(() => {});
+      
       await nodeManager.deleteNode(nodeId);
 
       get().removeNodeFromState(nodeId);

--- a/packages/transport-gun/src/directory-manager.ts
+++ b/packages/transport-gun/src/directory-manager.ts
@@ -161,14 +161,29 @@ export class DirectoryManager {
   ): () => void {
     const gun = GunInstanceManager.get();
     const listingsMap = new Map<string, DirectoryListing>();
+    const deletedNodes = new Set<string>();
 
     const ref = gun.get("directory");
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ref.map().on((data: any, nodeId: string) => {
+      // Skip already-known deleted nodes
+      if (deletedNodes.has(nodeId)) return;
+      
       if (!data || data === null || !data.isPublic) {
         listingsMap.delete(nodeId);
       } else {
+        // Validate the underlying node still exists
+        gun.get("nodes").get(nodeId).once((nodeData: any) => {
+          if (nodeData?.deletedAt || !nodeData?.name) {
+            // Node was deleted but listing wasn't cleaned up
+            deletedNodes.add(nodeId);
+            listingsMap.delete(nodeId);
+            // Auto-cleanup: mark as not public
+            gun.get("directory").get(nodeId).put({ isPublic: false, delistedAt: Date.now() });
+            handler(Array.from(listingsMap.values()));
+          }
+        });
         try {
           listingsMap.set(nodeId, {
             nodeId,


### PR DESCRIPTION
Ensure nodes are delisted from the directory upon deletion and enhance the cleanup process for listings of deleted nodes. This change prevents stale entries in the directory and maintains accurate visibility of active nodes.