### PR TITLE
feat(v1.2.0): Multi-Relay & Polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,43 @@ jobs:
           tauriScript: pnpm tauri
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}
+
+  deploy-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build web client
+        working-directory: apps/desktop
+        env:
+          VITE_GUN_RELAY_URL: ${{ secrets.VITE_GUN_RELAY_URL }}
+          VITE_LIVEKIT_URL: ${{ secrets.VITE_LIVEKIT_URL }}
+          VITE_LIVEKIT_API_KEY: ${{ secrets.VITE_LIVEKIT_API_KEY }}
+          VITE_IPFS_GATEWAY_URL: ${{ secrets.VITE_IPFS_GATEWAY_URL }}
+          VITE_IPFS_API_URL: ${{ secrets.VITE_IPFS_API_URL }}
+          VITE_GIPHY_API_KEY: ${{ secrets.VITE_GIPHY_API_KEY }}
+        run: pnpm exec vite build
+
+      - name: Deploy to production
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.PROD_SERVER_HOST }}
+          username: ${{ secrets.PROD_SERVER_USER }}
+          key: ${{ secrets.PROD_SERVER_SSH_KEY }}
+          source: "apps/desktop/dist/*"
+          target: "/opt/nodes-prod/web/"
+          strip_components: 3

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ coverage/
 npm-debug.log*
 pnpm-debug.log*
 
+# Deploy scripts with server IPs
+scripts/deploy-prod.sh
+
 # TypeScript
 *.tsbuildinfo
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -33,6 +33,12 @@
           "url": "wss://relay.nodes.services/*"
         },
         {
+          "url": "https://relay2.nodes.services/*"
+        },
+        {
+          "url": "wss://relay2.nodes.services/*"
+        },
+        {
           "url": "wss://voice.nodes.services/*"
         },
         {

--- a/apps/desktop/src/components/SplashScreen.tsx
+++ b/apps/desktop/src/components/SplashScreen.tsx
@@ -47,20 +47,17 @@ export function SplashScreen({ onDone, onFirstPaint, duration = 2800 }: SplashSc
     resize();
     window.addEventListener("resize", resize);
 
-    nodesRef.current = Array.from({ length: NODE_COUNT }, () => {
-      const radius = 1.8 + Math.random() * 2.2;
-      return {
-        x: Math.random() * window.innerWidth,
-        y: Math.random() * window.innerHeight,
-        vx: (Math.random() - 0.5) * 0.22,
-        vy: (Math.random() - 0.54) * 0.22,
-        radius,
-        glowRadius: radius * 4 + Math.random() * 8, // proportional, max ~26px
-        phase: Math.random() * Math.PI * 2,
-        brightness: 0.3 + Math.random() * 0.7,
-        color: ([0, 0, 1, 2, 1] as const)[Math.floor(Math.random() * 5)],
-      };
-    });
+    nodesRef.current = Array.from({ length: NODE_COUNT }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * 0.22,
+      vy: (Math.random() - 0.54) * 0.22, // slight upward drift, PS2-style
+      radius: 1.8 + Math.random() * 2.2,
+      glowRadius: 30 + Math.random() * 50,
+      phase: Math.random() * Math.PI * 2,
+      brightness: 0.3 + Math.random() * 0.7,
+      color: ([0, 0, 1, 2, 1] as const)[Math.floor(Math.random() * 5)],
+    }));
 
     const draw = (now: number) => {
       const t = now / 1000;

--- a/apps/desktop/src/components/channel/ChannelView.tsx
+++ b/apps/desktop/src/components/channel/ChannelView.tsx
@@ -136,6 +136,8 @@ export function ChannelView({
       clearUnread,
       clearChannel,
       setLoading,
+      loadFromCache,
+      saveToCache,
       messages: existingMessages,
     } = useMessageStore.getState();
 
@@ -151,15 +153,26 @@ export function ChannelView({
       setLoading(channelId, true);
     }
 
-    // Load message history
+    // Load message history - cache first, then network
     const nodeId = useNodeStore.getState().activeNodeId;
     const searchIndex = getSearchIndex();
     
+    // 1. Load from IndexedDB cache (instant)
+    loadFromCache(channelId).then((hadCache) => {
+      if (hadCache) {
+        setLoading(channelId, false);
+      }
+    });
+
+    // 2. Fetch from Gun (network)
     transport.message
       .getHistory(channelId, { limit: 50 })
       .then((history: TransportMessage[]) => {
         setMessages(channelId, history);
         setLoading(channelId, false);
+        
+        // 3. Save to cache for next startup
+        saveToCache(channelId);
         
         // Index all history messages for search
         if (nodeId) {

--- a/apps/desktop/src/components/discovery/NodeCard.tsx
+++ b/apps/desktop/src/components/discovery/NodeCard.tsx
@@ -2,6 +2,7 @@ import { Users, Clock } from "lucide-react";
 import type { DirectoryListing } from "@nodes/core";
 import { CATEGORY_LABELS, CATEGORY_ICONS } from "@nodes/core";
 import { useDiscoveryStore } from "../../stores/discovery-store";
+import { NodeIcon } from "../ui";
 
 interface NodeCardProps {
   listing: DirectoryListing;
@@ -21,25 +22,7 @@ export function NodeCard({ listing, onClick, variant = "grid" }: NodeCardProps) 
   );
   const isStale = daysSinceRefresh > 7;
 
-  // Get icon to display (IPFS image or emoji/letter)
-  const getNodeIcon = () => {
-    if (listing.icon?.startsWith("Qm") || listing.icon?.startsWith("bafy")) {
-      // IPFS CID - render as image
-      return (
-        <img
-          src={`https://ipfs.io/ipfs/${listing.icon}`}
-          alt={listing.name}
-          className="w-full h-full object-cover"
-        />
-      );
-    }
-    // Emoji or fallback to first letter
-    return (
-      <span className="text-2xl">
-        {listing.icon || listing.name.charAt(0).toUpperCase()}
-      </span>
-    );
-  };
+  const nodeIcon = <NodeIcon nodeId={listing.nodeId} icon={listing.icon || ""} name={listing.name} size="md" />;
 
   // Handle tag click (filter by tag)
   const handleTagClick = (e: React.MouseEvent, tag: string) => {
@@ -57,7 +40,7 @@ export function NodeCard({ listing, onClick, variant = "grid" }: NodeCardProps) 
       >
         {/* Icon */}
         <div className="w-12 h-12 rounded-lg bg-surface-dark flex items-center justify-center overflow-hidden flex-shrink-0">
-          {getNodeIcon()}
+          {nodeIcon}
         </div>
 
         {/* Content */}
@@ -105,7 +88,7 @@ export function NodeCard({ listing, onClick, variant = "grid" }: NodeCardProps) 
       <div className="flex items-start gap-3 mb-3">
         {/* Icon */}
         <div className="w-12 h-12 rounded-lg bg-surface-dark flex items-center justify-center overflow-hidden flex-shrink-0">
-          {getNodeIcon()}
+          {nodeIcon}
         </div>
 
         {/* Name & category */}

--- a/apps/desktop/src/components/discovery/NodePreviewModal.tsx
+++ b/apps/desktop/src/components/discovery/NodePreviewModal.tsx
@@ -6,6 +6,7 @@ import { NodeManager, ModerationManager } from "@nodes/transport-gun";
 import { useNodeStore } from "../../stores/node-store";
 import { useIdentityStore } from "../../stores/identity-store";
 import { useToastStore } from "../../stores/toast-store";
+import { NodeIcon } from "../ui";
 
 const nodeManager = new NodeManager();
 const moderationManager = new ModerationManager();
@@ -74,24 +75,6 @@ export function NodePreviewModal({ listing, onClose }: NodePreviewModalProps) {
     }
   };
 
-  // Get icon to display
-  const getNodeIcon = () => {
-    if (listing.icon?.startsWith("Qm") || listing.icon?.startsWith("bafy")) {
-      return (
-        <img
-          src={`https://ipfs.io/ipfs/${listing.icon}`}
-          alt={listing.name}
-          className="w-full h-full object-cover"
-        />
-      );
-    }
-    return (
-      <span className="text-4xl">
-        {listing.icon || listing.name.charAt(0).toUpperCase()}
-      </span>
-    );
-  };
-
   // Format date
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString("en-US", {
@@ -122,7 +105,7 @@ export function NodePreviewModal({ listing, onClose }: NodePreviewModalProps) {
         <div className="flex items-start gap-4 p-6 border-b border-surface-border">
           {/* Icon */}
           <div className="w-16 h-16 rounded-xl bg-surface-dark flex items-center justify-center overflow-hidden flex-shrink-0">
-            {getNodeIcon()}
+            <NodeIcon nodeId={listing.nodeId} icon={listing.icon || ""} name={listing.name} size="lg" />
           </div>
 
           {/* Title */}

--- a/apps/desktop/src/components/dm/DMSidebar.tsx
+++ b/apps/desktop/src/components/dm/DMSidebar.tsx
@@ -1,15 +1,12 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useDMStore } from "../../stores/dm-store";
 import { useIdentityStore } from "../../stores/identity-store";
-import { ProfileManager } from "@nodes/transport-gun";
+import { useDisplayNames } from "../../hooks/useDisplayNames";
 import { formatRelativeTime } from "../../utils/time";
 import { MemberListSkeleton, NameSkeleton, Avatar } from "../ui";
 import { NewDMModal } from "./NewDMModal";
-import { setCachedAvatarCid } from "../../hooks/useDisplayName";
 import type { DMConversation } from "@nodes/core";
 import type { KeyPair } from "@nodes/crypto";
-
-const profileManager = new ProfileManager();
 
 /**
  * DMSidebar displays the user's DM conversations.
@@ -26,41 +23,20 @@ export function DMSidebar({ onUserClick }: { onUserClick?: (userId: string) => v
   const keypair = useIdentityStore((s) => s.keypair);
   
   const [showNewDM, setShowNewDM] = useState(false);
-  const [resolvedNames, setResolvedNames] = useState<Record<string, string>>({});
+
+  // Collect all recipient keys for batch name resolution
+  const recipientKeys = useMemo(
+    () => conversations.map((c) => c.recipientKey),
+    [conversations]
+  );
+  
+  // Use shared IndexedDB-backed cache for display names and avatars
+  const { displayNames: resolvedNames, avatarCids, isLoading: namesLoading } = useDisplayNames(recipientKeys);
 
   // Load conversations on mount
   useEffect(() => {
     loadConversations();
   }, [loadConversations]);
-
-  // Resolve display names for conversation recipients
-  useEffect(() => {
-    async function resolveNames() {
-      const names: Record<string, string> = { ...resolvedNames };
-      let hasNew = false;
-
-      for (const conv of conversations) {
-        if (!names[conv.recipientKey]) {
-          hasNew = true;
-          try {
-            const profile = await profileManager.getPublicProfile(conv.recipientKey);
-            names[conv.recipientKey] = profile?.displayName || conv.recipientKey.slice(0, 8);
-            // Cache avatar CID for use by Avatar components
-            if (profile?.avatar) {
-              setCachedAvatarCid(conv.recipientKey, profile.avatar);
-            }
-          } catch {
-            names[conv.recipientKey] = conv.recipientKey.slice(0, 8);
-          }
-        }
-      }
-
-      if (hasNew) {
-        setResolvedNames(names);
-      }
-    }
-    resolveNames();
-  }, [conversations]);
 
   const handleSelectConversation = (conv: DMConversation) => {
     if (keypair) {
@@ -133,6 +109,7 @@ export function DMSidebar({ onUserClick }: { onUserClick?: (userId: string) => v
               key={conv.id}
               conversation={conv}
               displayName={resolvedNames[conv.recipientKey]}
+              avatarCid={avatarCids[conv.recipientKey]}
               isNameLoading={!resolvedNames[conv.recipientKey]}
               isActive={conv.id === activeConversationId}
               unreadCount={unreadCounts[conv.id] || 0}
@@ -152,6 +129,7 @@ export function DMSidebar({ onUserClick }: { onUserClick?: (userId: string) => v
 interface ConversationItemProps {
   conversation: DMConversation;
   displayName?: string;
+  avatarCid?: string;
   isNameLoading: boolean;
   isActive: boolean;
   unreadCount: number;
@@ -162,6 +140,7 @@ interface ConversationItemProps {
 function ConversationItem({
   conversation,
   displayName,
+  avatarCid,
   isNameLoading,
   isActive,
   unreadCount,
@@ -188,6 +167,7 @@ function ConversationItem({
         <Avatar
           publicKey={conversation.recipientKey}
           displayName={displayName}
+          avatarCid={avatarCid}
           size="md"
         />
       </div>

--- a/apps/desktop/src/components/profile/AvatarCropModal.tsx
+++ b/apps/desktop/src/components/profile/AvatarCropModal.tsx
@@ -7,13 +7,15 @@ interface AvatarCropModalProps {
   imageUrl: string;
   onCrop: (croppedBlob: Blob) => void;
   onCancel: () => void;
+  cropShape?: "round" | "rect";
+  title?: string;
 }
 
 /**
  * Modal for cropping an avatar image to a square.
  * Uses react-easy-crop for drag/zoom cropping with circular preview.
  */
-export function AvatarCropModal({ imageUrl, onCrop, onCancel }: AvatarCropModalProps) {
+export function AvatarCropModal({ imageUrl, onCrop, onCancel, cropShape = "round", title = "Crop Avatar" }: AvatarCropModalProps) {
   const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
@@ -42,7 +44,7 @@ export function AvatarCropModal({ imageUrl, onCrop, onCancel }: AvatarCropModalP
       <div className="bg-nodes-surface border border-nodes-border rounded-xl w-full max-w-lg shadow-2xl overflow-hidden">
         {/* Header */}
         <div className="px-4 py-3 border-b border-nodes-border">
-          <h2 className="text-lg font-semibold text-nodes-text">Crop Avatar</h2>
+          <h2 className="text-lg font-semibold text-nodes-text">{title}</h2>
           <p className="text-sm text-nodes-text-muted">
             Drag to reposition, scroll to zoom
           </p>
@@ -55,7 +57,7 @@ export function AvatarCropModal({ imageUrl, onCrop, onCancel }: AvatarCropModalP
             crop={crop}
             zoom={zoom}
             aspect={1}
-            cropShape="round"
+            cropShape={cropShape}
             showGrid={false}
             onCropChange={setCrop}
             onCropComplete={onCropComplete}

--- a/apps/desktop/src/components/settings/NetworkSettings.tsx
+++ b/apps/desktop/src/components/settings/NetworkSettings.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { useRelayStore } from "../../stores/relay-store";
+import { Input, Button } from "../ui";
+
+const DEFAULT_RELAYS = [
+  "wss://relay.nodes.services/gun",
+  "wss://relay2.nodes.services/gun",
+];
+
+/**
+ * Network settings section: relay management and connection status.
+ */
+export function NetworkSettings() {
+  const { relays, customRelays, addCustomRelay, removeCustomRelay } = useRelayStore();
+  const [newRelayUrl, setNewRelayUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAddRelay = () => {
+    setError(null);
+    
+    // Basic validation
+    const url = newRelayUrl.trim();
+    if (!url) {
+      setError("Please enter a relay URL");
+      return;
+    }
+    
+    if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
+      setError("URL must start with wss:// or ws://");
+      return;
+    }
+
+    try {
+      addCustomRelay(url);
+      setNewRelayUrl("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add relay");
+    }
+  };
+
+  const handleRemoveRelay = (url: string) => {
+    removeCustomRelay(url);
+  };
+
+  const formatLatency = (latency: number | null) => {
+    if (latency === null) return "—";
+    return `${latency}ms`;
+  };
+
+  const isDefaultRelay = (url: string) => DEFAULT_RELAYS.includes(url);
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <section>
+        <h2 className="text-lg font-semibold text-nodes-text mb-2">Network</h2>
+        <p className="text-nodes-text-muted text-sm">
+          Manage Gun relay servers for peer-to-peer synchronization.
+        </p>
+      </section>
+
+      {/* Current Relays */}
+      <section>
+        <h3 className="text-sm font-medium text-nodes-text mb-3">Connected Relays</h3>
+        <div className="space-y-2">
+          {relays.length === 0 ? (
+            <p className="text-nodes-text-muted text-sm py-4 text-center">
+              No relays configured. Add a relay to connect to the network.
+            </p>
+          ) : (
+            relays.map((relay) => (
+              <div
+                key={relay.url}
+                className="flex items-center justify-between p-3 bg-nodes-bg rounded-lg"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <span
+                    className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                      relay.connected ? "bg-nodes-accent" : "bg-red-500"
+                    }`}
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm text-nodes-text truncate">
+                      {relay.url}
+                    </p>
+                    <p className="text-xs text-nodes-text-muted">
+                      {relay.connected ? `Latency: ${formatLatency(relay.latency)}` : "Offline"}
+                      {isDefaultRelay(relay.url) && " • Default"}
+                    </p>
+                  </div>
+                </div>
+                {!isDefaultRelay(relay.url) && (
+                  <button
+                    onClick={() => handleRemoveRelay(relay.url)}
+                    className="p-1.5 text-nodes-text-muted hover:text-red-400 transition-colors shrink-0"
+                    title="Remove relay"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      {/* Add Custom Relay */}
+      <section>
+        <h3 className="text-sm font-medium text-nodes-text mb-3">Add Custom Relay</h3>
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            <Input
+              value={newRelayUrl}
+              onChange={(value) => {
+                setNewRelayUrl(value);
+                setError(null);
+              }}
+              placeholder="wss://your-relay.example.com/gun"
+              className="flex-1"
+              onKeyDown={(e) => e.key === "Enter" && handleAddRelay()}
+            />
+            <Button onClick={handleAddRelay}>Add</Button>
+          </div>
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+          <p className="text-xs text-nodes-text-muted">
+            Custom relays must expose a Gun WebSocket endpoint. Most relays use the path <code className="bg-nodes-bg px-1 py-0.5 rounded">/gun</code>.
+          </p>
+        </div>
+      </section>
+
+      {/* Info */}
+      <section className="pt-4 border-t border-nodes-border">
+        <h3 className="text-sm font-medium text-nodes-text mb-2">About Relays</h3>
+        <p className="text-xs text-nodes-text-muted leading-relaxed">
+          Gun relays are lightweight servers that help peers discover each other and sync data. 
+          They don't store your messages or identity — all data is encrypted end-to-end. 
+          Multiple relays provide redundancy: if one goes down, your messages still sync through others.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/settings/NodeAppearanceTab.tsx
+++ b/apps/desktop/src/components/settings/NodeAppearanceTab.tsx
@@ -1,25 +1,31 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { BUILT_IN_THEMES, type NodesTheme } from "@nodes/core";
 import { useThemeStore } from "../../stores/theme-store";
 import { useNodeStore } from "../../stores/node-store";
-import { Button } from "../ui";
+import { useToastStore } from "../../stores/toast-store";
+import { Button, NodeIcon } from "../ui";
+import { AvatarCropModal } from "../profile/AvatarCropModal";
+import { processNodeIconFromBlob } from "../../utils/image-processing";
+import { nodeIconManager } from "@nodes/transport-gun";
 
 /**
- * Node Appearance Tab - allows Node owners to set a custom theme for their Node.
- * When members enter a Node with a custom theme, it will override their personal theme
- * (if they have "respect node themes" enabled in their settings).
+ * Node Appearance Tab - allows Node owners to set a custom theme and custom icon.
  */
 export function NodeAppearanceTab() {
   const activeNodeId = useNodeStore((s) => s.activeNodeId);
   const nodes = useNodeStore((s) => s.nodes);
   const updateNode = useNodeStore((s) => s.updateNode);
   const { settings, allThemes } = useThemeStore();
+  const addToast = useToastStore((s) => s.addToast);
 
   const node = nodes.find((n) => n.id === activeNodeId);
   const [selectedThemeId, setSelectedThemeId] = useState<string | null>(
     node?.theme?.id || null
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [isUploadingIcon, setIsUploadingIcon] = useState(false);
+  const [cropImageUrl, setCropImageUrl] = useState<string | null>(null);
+  const iconInputRef = useRef<HTMLInputElement>(null);
 
   const handleSave = useCallback(async () => {
     if (!node) return;
@@ -48,12 +54,119 @@ export function NodeAppearanceTab() {
     }
   }, [node, updateNode]);
 
+  const handleIconFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = "";
+
+    const validTypes = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+    if (!validTypes.includes(file.type)) {
+      addToast("error", "Invalid image type. Use PNG, JPG, GIF, or WebP.");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      addToast("error", "Image too large. Maximum size is 5MB.");
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setCropImageUrl(url);
+  };
+
+  const handleIconCrop = useCallback(async (croppedBlob: Blob) => {
+    if (cropImageUrl) {
+      URL.revokeObjectURL(cropImageUrl);
+      setCropImageUrl(null);
+    }
+    if (!node) return;
+
+    setIsUploadingIcon(true);
+    try {
+      const iconBytes = await processNodeIconFromBlob(croppedBlob);
+      const { cid } = await nodeIconManager.uploadIcon(node.id, iconBytes);
+      await updateNode(node.id, { icon: cid });
+      addToast("success", "Node icon updated!");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to upload icon";
+      addToast("error", message);
+    } finally {
+      setIsUploadingIcon(false);
+    }
+  }, [cropImageUrl, node, updateNode, addToast]);
+
+  const handleIconCropCancel = () => {
+    if (cropImageUrl) {
+      URL.revokeObjectURL(cropImageUrl);
+      setCropImageUrl(null);
+    }
+  };
+
+  const handleRemoveIcon = useCallback(async () => {
+    if (!node) return;
+    setIsUploadingIcon(true);
+    try {
+      nodeIconManager.invalidate(node.id);
+      await updateNode(node.id, { icon: node.name.charAt(0).toUpperCase() });
+      addToast("success", "Node icon removed");
+    } finally {
+      setIsUploadingIcon(false);
+    }
+  }, [node, updateNode, addToast]);
+
   if (!node) return null;
 
   const hasChanges = (selectedThemeId || null) !== (node.theme?.id || null);
 
   return (
     <div className="space-y-6">
+      {/* Node Icon Section */}
+      <div>
+        <h3 className="text-sm font-semibold text-nodes-text mb-2">
+          Node Icon
+        </h3>
+        <p className="text-sm text-nodes-text-muted mb-4">
+          Upload a custom image for your Node's icon. It will appear in the sidebar,
+          directory, and invite previews.
+        </p>
+
+        <div className="flex items-center gap-4">
+          {/* Icon preview */}
+          <div className="w-16 h-16 rounded-2xl bg-nodes-bg border border-nodes-border flex items-center justify-center overflow-hidden">
+            <NodeIcon nodeId={node.id} icon={node.icon} name={node.name} size="lg" />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <input
+              ref={iconInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              onChange={handleIconFileChange}
+              className="hidden"
+            />
+            <Button
+              variant="ghost"
+              onClick={() => iconInputRef.current?.click()}
+              disabled={isUploadingIcon}
+            >
+              {isUploadingIcon ? "Uploading..." : "Upload Image"}
+            </Button>
+            {node.icon && (node.icon.startsWith("Qm") || node.icon.startsWith("bafy")) && (
+              <Button
+                variant="ghost"
+                onClick={handleRemoveIcon}
+                disabled={isUploadingIcon}
+              >
+                Remove Icon
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Separator */}
+      <div className="border-t border-nodes-border" />
+
+      {/* Theme Section */}
       <div>
         <h3 className="text-sm font-semibold text-nodes-text mb-2">
           Node Theme
@@ -152,6 +265,17 @@ export function NodeAppearanceTab() {
           </li>
         </ul>
       </div>
+
+      {/* Crop Modal */}
+      {cropImageUrl && (
+        <AvatarCropModal
+          imageUrl={cropImageUrl}
+          onCrop={handleIconCrop}
+          onCancel={handleIconCropCancel}
+          cropShape="rect"
+          title="Crop Node Icon"
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/settings/SettingsPage.tsx
+++ b/apps/desktop/src/components/settings/SettingsPage.tsx
@@ -5,9 +5,10 @@ import { SocialSettings } from "./SocialSettings";
 import { VoiceSettings } from "./VoiceSettings";
 import { AppearanceSettings } from "./AppearanceSettings";
 import { NotificationSettings } from "./NotificationSettings";
+import { NetworkSettings } from "./NetworkSettings";
 import { AboutSettings } from "./AboutSettings";
 
-type SettingsSection = "account" | "privacy" | "social" | "voice" | "appearance" | "notifications" | "about";
+type SettingsSection = "account" | "privacy" | "social" | "voice" | "appearance" | "notifications" | "network" | "about";
 
 interface SettingsPageProps {
   onClose: () => void;
@@ -69,6 +70,15 @@ const sections: { id: SettingsSection; label: string; icon: ReactNode }[] = [
     ),
   },
   {
+    id: "network",
+    label: "Network",
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+      </svg>
+    ),
+  },
+  {
     id: "about",
     label: "About",
     icon: (
@@ -108,6 +118,8 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
         return <AppearanceSettings />;
       case "notifications":
         return <NotificationSettings />;
+      case "network":
+        return <NetworkSettings />;
       case "about":
         return <AboutSettings />;
       default:

--- a/apps/desktop/src/components/settings/index.ts
+++ b/apps/desktop/src/components/settings/index.ts
@@ -5,6 +5,7 @@ export { SocialSettings } from './SocialSettings';
 export { VoiceSettings } from './VoiceSettings';
 export { AppearanceSettings } from './AppearanceSettings';
 export { NotificationSettings } from './NotificationSettings';
+export { NetworkSettings } from './NetworkSettings';
 export { AboutSettings } from './AboutSettings';
 export { RolesTab } from './RolesTab';
 export { RoleEditor } from './RoleEditor';

--- a/apps/desktop/src/components/social/RequestsPanel.tsx
+++ b/apps/desktop/src/components/social/RequestsPanel.tsx
@@ -1,12 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSocialStore } from "../../stores/social-store";
 import { useNavigationStore } from "../../stores/navigation-store";
-import { ProfileManager } from "@nodes/transport-gun";
+import { useDisplayNames } from "../../hooks/useDisplayNames";
 import { NameSkeleton, Avatar } from "../ui";
-import { setCachedAvatarCid } from "../../hooks/useDisplayName";
 import type { FriendRequest, Friend } from "@nodes/core";
-
-const profileManager = new ProfileManager();
 
 type TabType = "friends" | "incoming" | "outgoing" | "blocked";
 
@@ -19,8 +16,6 @@ export function RequestsPanel({ onUserClick }: { onUserClick?: (userId: string) 
   const friendsTabFromStore = useNavigationStore((s) => s.friendsTab);
   const setFriendsTabInStore = useNavigationStore((s) => s.setFriendsTab);
   const [activeTab, setActiveTab] = useState<TabType>(friendsTabFromStore);
-  const [resolvedNames, setResolvedNames] = useState<Record<string, string>>({});
-  const [avatarCids, setAvatarCids] = useState<Record<string, string>>({});
 
   const friends = useSocialStore((s) => s.friends);
   const incomingRequests = useSocialStore((s) => s.incomingRequests);
@@ -33,43 +28,17 @@ export function RequestsPanel({ onUserClick }: { onUserClick?: (userId: string) 
   const unblockUser = useSocialStore((s) => s.unblockUser);
 
   // Collect all public keys that need name resolution
-  useEffect(() => {
-    async function resolveNames() {
-      const allKeys = new Set<string>();
-      
-      friends.forEach((f) => allKeys.add(f.publicKey));
-      incomingRequests.forEach((r) => allKeys.add(r.fromKey));
-      outgoingRequests.forEach((r) => allKeys.add(r.toKey));
-      blockedUsers.forEach((b) => allKeys.add(b.publicKey));
-
-      const names: Record<string, string> = { ...resolvedNames };
-      let hasNew = false;
-
-      for (const key of allKeys) {
-        if (!names[key]) {
-          hasNew = true;
-          try {
-            const profile = await profileManager.getPublicProfile(key);
-            names[key] = profile?.displayName || key.slice(0, 8);
-            // Cache avatar CID for use by Avatar components
-            const avatarCid = profile?.avatar;
-            if (avatarCid) {
-              setCachedAvatarCid(key, avatarCid);
-              setAvatarCids((prev) => ({ ...prev, [key]: avatarCid }));
-            }
-          } catch {
-            names[key] = key.slice(0, 8);
-          }
-        }
-      }
-
-      if (hasNew) {
-        setResolvedNames(names);
-      }
-    }
-    resolveNames();
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- resolvedNames is intentionally excluded to prevent infinite loops
+  const allKeys = useMemo(() => {
+    const keys = new Set<string>();
+    friends.forEach((f) => keys.add(f.publicKey));
+    incomingRequests.forEach((r) => keys.add(r.fromKey));
+    outgoingRequests.forEach((r) => keys.add(r.toKey));
+    blockedUsers.forEach((b) => keys.add(b.publicKey));
+    return Array.from(keys);
   }, [friends, incomingRequests, outgoingRequests, blockedUsers]);
+
+  // Use shared IndexedDB-backed cache for display names and avatars
+  const { displayNames: resolvedNames, avatarCids, isLoading: namesLoading } = useDisplayNames(allKeys);
 
   const getName = (publicKey: string) => resolvedNames[publicKey];
   const isNameLoading = (publicKey: string) => !resolvedNames[publicKey];

--- a/apps/desktop/src/components/ui/Input.tsx
+++ b/apps/desktop/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { type InputHTMLAttributes } from "react";
+import { type InputHTMLAttributes, useState, useCallback } from "react";
 
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> {
   label?: string;
@@ -15,10 +15,25 @@ export function Input({
   value,
   onChange,
   className = "",
+  type,
+  onKeyDown,
+  onKeyUp,
   ...props
 }: InputProps) {
   const charCount = typeof value === "string" ? value.length : 0;
   const showCounter = maxLength !== undefined;
+  const isPassword = type === "password";
+  const [capsLock, setCapsLock] = useState(false);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isPassword) setCapsLock(e.getModifierState("CapsLock"));
+    onKeyDown?.(e);
+  }, [isPassword, onKeyDown]);
+
+  const handleKeyUp = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isPassword) setCapsLock(e.getModifierState("CapsLock"));
+    onKeyUp?.(e);
+  }, [isPassword, onKeyUp]);
 
   return (
     <div className="w-full">
@@ -35,7 +50,10 @@ export function Input({
       <input
         value={value}
         maxLength={maxLength}
+        type={type}
         onChange={(e) => onChange?.(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
         className={`
           w-full bg-nodes-surface text-nodes-text
           border rounded-lg px-4 py-3
@@ -49,6 +67,14 @@ export function Input({
         `}
         {...props}
       />
+      {isPassword && capsLock && (
+        <p className="text-warning text-xs mt-1 flex items-center gap-1">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5 shrink-0">
+            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+          </svg>
+          Caps Lock is on
+        </p>
+      )}
       {error && (
         <p className="text-nodes-danger text-xs mt-1">{error}</p>
       )}

--- a/apps/desktop/src/components/ui/NodeIcon.tsx
+++ b/apps/desktop/src/components/ui/NodeIcon.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { useNodeIcon } from "../../hooks/useNodeIcon";
+
+interface NodeIconProps {
+  nodeId?: string;
+  icon: string;
+  name: string;
+  size?: "sm" | "md" | "lg" | "xl";
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "w-8 h-8 text-sm",
+  md: "w-12 h-12 text-lg",
+  lg: "w-16 h-16 text-2xl",
+  xl: "w-20 h-20 text-4xl",
+};
+
+/**
+ * Check if a string is an IPFS CID (Qm... or bafy...).
+ */
+function isIpfsCid(value: string): boolean {
+  return value.startsWith("Qm") || value.startsWith("bafy");
+}
+
+/**
+ * Check if a string contains an emoji (non-ASCII visual character).
+ */
+function isEmoji(value: string): boolean {
+  // Match common emoji patterns: surrogate pairs, variation selectors, ZWJ sequences
+  return /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/u.test(value);
+}
+
+/**
+ * Get the first visual character/emoji from a string.
+ * Uses Intl.Segmenter if available for proper grapheme cluster handling,
+ * falls back to Array.from for basic emoji support.
+ */
+function getFirstGrapheme(str: string): string {
+  if (typeof Intl !== "undefined" && Intl.Segmenter) {
+    const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+    const first = segmenter.segment(str)[Symbol.iterator]().next().value;
+    return first?.segment ?? str.charAt(0);
+  }
+  // Fallback: Array.from splits on code points (handles surrogate pairs)
+  return Array.from(str)[0] ?? str.charAt(0);
+}
+
+/**
+ * Shared NodeIcon component for rendering Node icons.
+ * Handles IPFS images (via cached fetch pipeline), emojis, and letter fallbacks.
+ */
+export function NodeIcon({ nodeId, icon, name, size = "md", className = "" }: NodeIconProps) {
+  const [imgError, setImgError] = useState(false);
+  const isCid = icon ? isIpfsCid(icon) : false;
+  const { iconUrl, isLoading } = useNodeIcon(
+    isCid ? nodeId : undefined,
+    isCid ? icon : undefined
+  );
+
+  const sizeClass = sizeClasses[size];
+
+  // IPFS CID → render via cached pipeline
+  if (isCid && !imgError) {
+    if (isLoading) {
+      return (
+        <div className={`${sizeClass} rounded-lg overflow-hidden flex items-center justify-center bg-nodes-bg animate-pulse ${className}`} />
+      );
+    }
+    if (iconUrl) {
+      return (
+        <div className={`${sizeClass} rounded-lg overflow-hidden flex items-center justify-center ${className}`}>
+          <img
+            src={iconUrl}
+            alt={name}
+            className="w-full h-full object-cover"
+            onError={() => setImgError(true)}
+          />
+        </div>
+      );
+    }
+  }
+
+  // Emoji or letter fallback
+  const displayChar = icon && icon.trim()
+    ? isEmoji(icon) ? getFirstGrapheme(icon) : icon.charAt(0).toUpperCase()
+    : name.charAt(0).toUpperCase();
+
+  return (
+    <span className={`${sizeClass} flex items-center justify-center font-semibold ${className}`}>
+      {displayChar}
+    </span>
+  );
+}

--- a/apps/desktop/src/components/ui/RelayStatusIndicator.tsx
+++ b/apps/desktop/src/components/ui/RelayStatusIndicator.tsx
@@ -1,0 +1,125 @@
+import { useState, useRef, useEffect } from "react";
+import { useRelayStore } from "../../stores/relay-store";
+
+/**
+ * RelayStatusIndicator shows the health status of connected Gun relays.
+ * - Green: All relays connected
+ * - Yellow: Some relays connected (degraded)
+ * - Red: No relays connected
+ * Clicking shows a popover with individual relay details.
+ */
+export function RelayStatusIndicator() {
+  const { relays, connectedCount, totalCount } = useRelayStore();
+  const [showPopover, setShowPopover] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setShowPopover(false);
+      }
+    }
+
+    if (showPopover) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showPopover]);
+
+  // Don't render if not monitoring
+  if (totalCount === 0) return null;
+
+  const getStatusColor = () => {
+    if (connectedCount === 0) return "bg-red-500";
+    if (connectedCount < totalCount) return "bg-yellow-500";
+    return "bg-nodes-accent";
+  };
+
+  const getStatusText = () => {
+    if (connectedCount === 0) return "Disconnected";
+    if (connectedCount < totalCount) return "Degraded";
+    return "Connected";
+  };
+
+  const formatLatency = (latency: number | null) => {
+    if (latency === null) return "—";
+    return `${latency}ms`;
+  };
+
+  const formatRelayName = (url: string) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.hostname;
+    } catch {
+      return url;
+    }
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        onClick={() => setShowPopover(!showPopover)}
+        className="flex items-center gap-1.5 text-nodes-text-muted hover:text-nodes-text transition-colors px-1.5 py-0.5 rounded hover:bg-nodes-bg/50"
+        title={`Relay Status: ${getStatusText()} (${connectedCount}/${totalCount})`}
+      >
+        <span className={`w-2 h-2 rounded-full ${getStatusColor()}`} />
+        <span className="text-xs">
+          {connectedCount}/{totalCount}
+        </span>
+      </button>
+
+      {showPopover && (
+        <div
+          ref={popoverRef}
+          className="absolute bottom-full left-0 mb-2 w-64 bg-nodes-surface border border-nodes-border rounded-lg shadow-lg z-50"
+        >
+          <div className="px-3 py-2 border-b border-nodes-border">
+            <h3 className="text-sm font-medium text-nodes-text">Relay Status</h3>
+            <p className="text-xs text-nodes-text-muted mt-0.5">
+              {getStatusText()} ({connectedCount}/{totalCount} relays)
+            </p>
+          </div>
+          <div className="max-h-48 overflow-y-auto">
+            {relays.map((relay) => (
+              <div
+                key={relay.url}
+                className="px-3 py-2 flex items-center justify-between border-b border-nodes-border/50 last:border-b-0"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span
+                    className={`w-2 h-2 rounded-full shrink-0 ${
+                      relay.connected ? "bg-nodes-accent" : "bg-red-500"
+                    }`}
+                  />
+                  <span className="text-xs text-nodes-text truncate">
+                    {formatRelayName(relay.url)}
+                  </span>
+                </div>
+                <span
+                  className={`text-xs shrink-0 ml-2 ${
+                    relay.connected ? "text-nodes-text-muted" : "text-red-400"
+                  }`}
+                >
+                  {relay.connected ? formatLatency(relay.latency) : "offline"}
+                </span>
+              </div>
+            ))}
+          </div>
+          {relays.length > 0 && (
+            <div className="px-3 py-1.5 border-t border-nodes-border text-xs text-nodes-text-muted">
+              Last checked: {relays[0]?.lastChecked ? new Date(relays[0].lastChecked).toLocaleTimeString() : "—"}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ui/index.ts
+++ b/apps/desktop/src/components/ui/index.ts
@@ -5,5 +5,7 @@ export { Badge } from "./Badge";
 export { CopyablePublicKey } from "./CopyablePublicKey";
 export { PassphraseStrength } from "./PassphraseStrength";
 export { ConnectionStatus, ConnectionIndicator } from "./ConnectionStatus";
+export { RelayStatusIndicator } from "./RelayStatusIndicator";
 export { Skeleton, ChannelSkeleton, ChannelListSkeleton, MemberSkeleton, MemberListSkeleton, NameSkeleton } from "./Skeleton";
 export { Avatar, getAvatarColor } from "./Avatar";
+export { NodeIcon } from "./NodeIcon";

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { useMemberSubscription } from "./useMemberSubscription";
 export { useChannelSubscription } from "./useChannelSubscription";
 export { useRoleSubscriptions } from "./useRoleSubscriptions";
 export { useAvatar } from "./useAvatar";
+export { useNodeIcon } from "./useNodeIcon";
 export { useVoiceChannelParticipants } from "./useVoiceChannelParticipants";
 export { useModerationEvents } from "./useModerationEvents";
 export { useSlowMode } from "./useSlowMode";

--- a/apps/desktop/src/hooks/useAppVisibility.ts
+++ b/apps/desktop/src/hooks/useAppVisibility.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+import { create } from "zustand";
+
+interface AppVisibilityState {
+  /** Whether the app window/tab is currently visible */
+  isVisible: boolean;
+  /** Whether the app just resumed from a long sleep (>30s gap) */
+  didWake: boolean;
+  setVisible: (visible: boolean) => void;
+  setDidWake: (woke: boolean) => void;
+}
+
+export const useAppVisibilityStore = create<AppVisibilityState>((set) => ({
+  isVisible: true,
+  didWake: false,
+  setVisible: (visible) => set({ isVisible: visible }),
+  setDidWake: (woke) => set({ didWake: woke }),
+}));
+
+/**
+ * Detects visibility changes and system sleep/wake.
+ *
+ * - Uses `document.visibilitychange` for tab/window hide/show.
+ * - Detects sleep/wake by comparing expected vs actual interval gap.
+ *   If the gap exceeds 30 seconds, the system likely slept and woke.
+ *
+ * Mount this once at the app root (AppShell).
+ */
+export function useAppVisibility() {
+  const lastTickRef = useRef(Date.now());
+
+  useEffect(() => {
+    const { setVisible, setDidWake } = useAppVisibilityStore.getState();
+
+    // Visibility change (tab switch, window minimise, Tauri hide-to-tray)
+    const handleVisibilityChange = () => {
+      const visible = !document.hidden;
+      setVisible(visible);
+
+      if (visible) {
+        // Check if we were away for a long time (sleep/wake)
+        const gap = Date.now() - lastTickRef.current;
+        if (gap > 30_000) {
+          setDidWake(true);
+          // Reset after a short delay so consumers can react once
+          setTimeout(() => setDidWake(false), 1_000);
+        }
+      }
+
+      lastTickRef.current = Date.now();
+    };
+
+    // Heartbeat to detect gaps caused by system sleep
+    // If the gap between ticks exceeds 30s, we slept and woke.
+    const heartbeat = setInterval(() => {
+      const now = Date.now();
+      const gap = now - lastTickRef.current;
+      lastTickRef.current = now;
+
+      if (gap > 30_000 && !document.hidden) {
+        const { setDidWake, setVisible } = useAppVisibilityStore.getState();
+        setVisible(true);
+        setDidWake(true);
+        setTimeout(() => useAppVisibilityStore.getState().setDidWake(false), 1_000);
+      }
+    }, 5_000);
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearInterval(heartbeat);
+    };
+  }, []);
+}

--- a/apps/desktop/src/hooks/useChannelSubscription.ts
+++ b/apps/desktop/src/hooks/useChannelSubscription.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { NodeManager } from "@nodes/transport-gun";
 import { useNodeStore } from "../stores/node-store";
 import { useIdentityStore } from "../stores/identity-store";
+import { useAppVisibilityStore } from "./useAppVisibility";
 
 const nodeManager = new NodeManager();
 
@@ -17,6 +18,7 @@ export function useChannelSubscription() {
   const isAuthenticated = useIdentityStore((s) => s.isAuthenticated);
   const publicKey = useIdentityStore((s) => s.publicKey);
   const activeNodeId = useNodeStore((s) => s.activeNodeId);
+  const isVisible = useAppVisibilityStore((s) => s.isVisible);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -26,7 +28,7 @@ export function useChannelSubscription() {
       intervalRef.current = null;
     }
 
-    if (!isAuthenticated || !publicKey || !activeNodeId) return;
+    if (!isAuthenticated || !publicKey || !activeNodeId || !isVisible) return;
 
     const pollChannels = async () => {
       try {
@@ -86,5 +88,5 @@ export function useChannelSubscription() {
         intervalRef.current = null;
       }
     };
-  }, [isAuthenticated, publicKey, activeNodeId]);
+  }, [isAuthenticated, publicKey, activeNodeId, isVisible]);
 }

--- a/apps/desktop/src/hooks/useDisplayName.ts
+++ b/apps/desktop/src/hooks/useDisplayName.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { ProfileManager } from "@nodes/transport-gun";
 import { useNodeStore } from "../stores/node-store";
 import { useIdentityStore } from "../stores/identity-store";
+import { getCache, setCache, CacheKeys, deleteCache } from "../services/app-cache";
 
 // Module-level cache to avoid repeated lookups
 const displayNameCache = new Map<string, string>();
@@ -10,6 +11,45 @@ const displayNameCache = new Map<string, string>();
 const avatarCidCache = new Map<string, string>();
 
 const profileManager = new ProfileManager();
+
+// Flag to track if we've loaded from IndexedDB
+let cacheLoaded = false;
+
+// Load display name cache from IndexedDB on module init
+async function loadDisplayNameCacheFromDb(): Promise<void> {
+  if (cacheLoaded) return;
+  try {
+    const cached = await getCache<Record<string, string>>(CacheKeys.displayNames());
+    if (cached) {
+      Object.entries(cached).forEach(([key, value]) => {
+        displayNameCache.set(key, value);
+      });
+    }
+    cacheLoaded = true;
+  } catch {
+    // Non-fatal, continue without cache
+  }
+}
+
+// Save display name cache to IndexedDB (debounced)
+let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+function saveDisplayNameCacheToDb(): void {
+  if (saveTimeout) clearTimeout(saveTimeout);
+  saveTimeout = setTimeout(async () => {
+    try {
+      const obj: Record<string, string> = {};
+      displayNameCache.forEach((value, key) => {
+        obj[key] = value;
+      });
+      await setCache(CacheKeys.displayNames(), obj);
+    } catch {
+      // Non-fatal
+    }
+  }, 1000); // Debounce 1 second
+}
+
+// Initialize cache on module load
+loadDisplayNameCacheFromDb();
 
 /**
  * Hook to resolve a public key to a display name.
@@ -57,6 +97,7 @@ export function useDisplayName(publicKey: string | undefined): {
     // Check if it's the current user
     if (publicKey === identityPublicKey && identityDisplayName) {
       displayNameCache.set(publicKey, identityDisplayName);
+      saveDisplayNameCacheToDb();
       setDisplayName(identityDisplayName);
       setIsLoading(false);
       return;
@@ -66,6 +107,7 @@ export function useDisplayName(publicKey: string | undefined): {
     const nodeStoreCache = useNodeStore.getState().displayNameCache;
     if (nodeStoreCache[publicKey]?.name) {
       displayNameCache.set(publicKey, nodeStoreCache[publicKey].name);
+      saveDisplayNameCacheToDb();
       setDisplayName(nodeStoreCache[publicKey].name);
       setIsLoading(false);
       return;
@@ -79,6 +121,7 @@ export function useDisplayName(publicKey: string | undefined): {
       );
       if (member?.displayName) {
         displayNameCache.set(publicKey, member.displayName);
+        saveDisplayNameCacheToDb();
         setDisplayName(member.displayName);
         setIsLoading(false);
         return;
@@ -94,6 +137,7 @@ export function useDisplayName(publicKey: string | undefined): {
         const name =
           profile?.displayName || `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
         displayNameCache.set(publicKey, name);
+        saveDisplayNameCacheToDb();
         setDisplayName(name);
         
         // Also cache avatar CID if present
@@ -105,6 +149,7 @@ export function useDisplayName(publicKey: string | undefined): {
         if (cancelled) return;
         const fallback = `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
         displayNameCache.set(publicKey, fallback);
+        saveDisplayNameCacheToDb();
         setDisplayName(fallback);
       })
       .finally(() => {
@@ -117,6 +162,21 @@ export function useDisplayName(publicKey: string | undefined): {
   }, [publicKey, activeNodeId, identityPublicKey, identityDisplayName]);
 
   return { displayName, isLoading };
+}
+
+/**
+ * Get a cached display name for a public key.
+ */
+export function getCachedDisplayName(publicKey: string): string | undefined {
+  return displayNameCache.get(publicKey);
+}
+
+/**
+ * Set a cached display name for a public key (also saves to IndexedDB).
+ */
+export function setCachedDisplayName(publicKey: string, name: string): void {
+  displayNameCache.set(publicKey, name);
+  saveDisplayNameCacheToDb();
 }
 
 /**
@@ -139,4 +199,7 @@ export function setCachedAvatarCid(publicKey: string, cid: string): void {
 export function clearDisplayNameCache(): void {
   displayNameCache.clear();
   avatarCidCache.clear();
+  // Also clear IndexedDB cache
+  deleteCache(CacheKeys.displayNames()).catch(() => {});
+  cacheLoaded = false;
 }

--- a/apps/desktop/src/hooks/useDisplayNames.ts
+++ b/apps/desktop/src/hooks/useDisplayNames.ts
@@ -1,11 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { ProfileManager } from "@nodes/transport-gun";
 import { useNodeStore } from "../stores/node-store";
 import { useIdentityStore } from "../stores/identity-store";
-import { setCachedAvatarCid } from "./useDisplayName";
-
-// Module-level cache
-const displayNameCache = new Map<string, string>();
+import { setCachedAvatarCid, getCachedDisplayName, setCachedDisplayName, getCachedAvatarCid } from "./useDisplayName";
 
 const profileManager = new ProfileManager();
 
@@ -17,9 +14,11 @@ const profileManager = new ProfileManager();
  */
 export function useDisplayNames(publicKeys: string[]): {
   displayNames: Record<string, string>;
+  avatarCids: Record<string, string>;
   isLoading: boolean;
 } {
   const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
+  const [avatarCids, setAvatarCids] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
 
   const activeNodeId = useNodeStore((s) => s.activeNodeId);
@@ -29,9 +28,27 @@ export function useDisplayNames(publicKeys: string[]): {
   // Create a stable key for the publicKeys array
   const publicKeysKey = Array.from(new Set(publicKeys)).sort().join(",");
 
+  // Initialize with cached values synchronously (instant render)
+  const initialCached = useMemo(() => {
+    const names: Record<string, string> = {};
+    const avatars: Record<string, string> = {};
+    for (const publicKey of publicKeys) {
+      if (publicKey === "system") {
+        names[publicKey] = "System";
+      } else {
+        const cachedName = getCachedDisplayName(publicKey);
+        if (cachedName) names[publicKey] = cachedName;
+        const cachedAvatar = getCachedAvatarCid(publicKey);
+        if (cachedAvatar) avatars[publicKey] = cachedAvatar;
+      }
+    }
+    return { names, avatars };
+  }, [publicKeysKey]);
+
   useEffect(() => {
     if (publicKeys.length === 0) {
       setDisplayNames({});
+      setAvatarCids({});
       setIsLoading(false);
       return;
     }
@@ -39,27 +56,26 @@ export function useDisplayNames(publicKeys: string[]): {
     let cancelled = false;
 
     const resolveNames = async () => {
-      setIsLoading(true);
-      const result: Record<string, string> = {};
+      // Start with cached values (don't show empty while loading)
+      const result: Record<string, string> = { ...initialCached.names };
+      const avatars: Record<string, string> = { ...initialCached.avatars };
       const members = useNodeStore.getState().members;
       const missingKeys: string[] = [];
 
-      for (const publicKey of publicKeys) {
-        // System
-        if (publicKey === "system") {
-          result[publicKey] = "System";
-          continue;
-        }
+      // Set cached values immediately so UI isn't blank
+      if (Object.keys(result).length > 0) {
+        setDisplayNames(result);
+        setAvatarCids(avatars);
+      }
+      setIsLoading(true);
 
-        // Check cache
-        if (displayNameCache.has(publicKey)) {
-          result[publicKey] = displayNameCache.get(publicKey)!;
-          continue;
-        }
+      for (const publicKey of publicKeys) {
+        // Already in result from cache
+        if (result[publicKey]) continue;
 
         // Check current user
         if (publicKey === identityPublicKey && identityDisplayName) {
-          displayNameCache.set(publicKey, identityDisplayName);
+          setCachedDisplayName(publicKey, identityDisplayName);
           result[publicKey] = identityDisplayName;
           continue;
         }
@@ -70,7 +86,7 @@ export function useDisplayNames(publicKeys: string[]): {
             (m) => m.publicKey === publicKey
           );
           if (member?.displayName) {
-            displayNameCache.set(publicKey, member.displayName);
+            setCachedDisplayName(publicKey, member.displayName);
             result[publicKey] = member.displayName;
             continue;
           }
@@ -81,29 +97,33 @@ export function useDisplayNames(publicKeys: string[]): {
       }
 
       // Fetch all missing keys in parallel
-      await Promise.all(
-        missingKeys.map(async (publicKey) => {
-          try {
-            const profile = await profileManager.getPublicProfile(publicKey);
-            const name =
-              profile?.displayName ||
-              `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
-            displayNameCache.set(publicKey, name);
-            result[publicKey] = name;
-            // Cache avatar CID for use by Avatar components
-            if (profile?.avatar) {
-              setCachedAvatarCid(publicKey, profile.avatar);
+      if (missingKeys.length > 0) {
+        await Promise.all(
+          missingKeys.map(async (publicKey) => {
+            try {
+              const profile = await profileManager.getPublicProfile(publicKey);
+              const name =
+                profile?.displayName ||
+                `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
+              setCachedDisplayName(publicKey, name);
+              result[publicKey] = name;
+              // Cache avatar CID for use by Avatar components
+              if (profile?.avatar) {
+                setCachedAvatarCid(publicKey, profile.avatar);
+                avatars[publicKey] = profile.avatar;
+              }
+            } catch {
+              const fallback = `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
+              setCachedDisplayName(publicKey, fallback);
+              result[publicKey] = fallback;
             }
-          } catch {
-            const fallback = `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`;
-            displayNameCache.set(publicKey, fallback);
-            result[publicKey] = fallback;
-          }
-        })
-      );
+          })
+        );
+      }
 
       if (!cancelled) {
         setDisplayNames(result);
+        setAvatarCids(avatars);
         setIsLoading(false);
       }
     };
@@ -113,7 +133,7 @@ export function useDisplayNames(publicKeys: string[]): {
     return () => {
       cancelled = true;
     };
-  }, [publicKeysKey, activeNodeId, identityPublicKey, identityDisplayName]);
+  }, [publicKeysKey, activeNodeId, identityPublicKey, identityDisplayName, initialCached]);
 
-  return { displayNames, isLoading };
+  return { displayNames, avatarCids, isLoading };
 }

--- a/apps/desktop/src/hooks/useMemberSubscription.ts
+++ b/apps/desktop/src/hooks/useMemberSubscription.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { NodeManager } from "@nodes/transport-gun";
 import { useNodeStore } from "../stores/node-store";
 import { useIdentityStore } from "../stores/identity-store";
+import { useAppVisibilityStore } from "./useAppVisibility";
 
 const nodeManager = new NodeManager();
 
@@ -19,6 +20,7 @@ export function useMemberSubscription() {
   const isAuthenticated = useIdentityStore((s) => s.isAuthenticated);
   const publicKey = useIdentityStore((s) => s.publicKey);
   const activeNodeId = useNodeStore((s) => s.activeNodeId);
+  const isVisible = useAppVisibilityStore((s) => s.isVisible);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -28,7 +30,7 @@ export function useMemberSubscription() {
       intervalRef.current = null;
     }
 
-    if (!isAuthenticated || !publicKey || !activeNodeId) return;
+    if (!isAuthenticated || !publicKey || !activeNodeId || !isVisible) return;
 
     // Poll for member changes periodically
     const pollMembers = async () => {
@@ -99,5 +101,5 @@ export function useMemberSubscription() {
         intervalRef.current = null;
       }
     };
-  }, [isAuthenticated, publicKey, activeNodeId]);
+  }, [isAuthenticated, publicKey, activeNodeId, isVisible]);
 }

--- a/apps/desktop/src/hooks/useNodeDeletionGuard.ts
+++ b/apps/desktop/src/hooks/useNodeDeletionGuard.ts
@@ -53,6 +53,16 @@ export function useNodeDeletionGuard() {
           } else {
             themeStore.clearNodeTheme();
           }
+        },
+        // onIconChange — update active node's icon live for other members
+        (icon) => {
+          const activeNodeId = useNodeStore.getState().activeNodeId;
+          if (activeNodeId !== node.id) return; // only update active node
+          useNodeStore.setState((state) => ({
+            nodes: state.nodes.map((n) =>
+              n.id === node.id ? { ...n, icon: icon ?? "" } : n
+            ),
+          }));
         }
       );
 

--- a/apps/desktop/src/hooks/useNodeIcon.ts
+++ b/apps/desktop/src/hooks/useNodeIcon.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef } from "react";
+import { nodeIconManager } from "@nodes/transport-gun";
+
+interface UseNodeIconResult {
+  iconUrl: string | null;
+  isLoading: boolean;
+}
+
+/**
+ * Hook to fetch and cache a Node's icon from IPFS.
+ * Mirrors the useAvatar hook pattern.
+ *
+ * @param nodeId - The Node's ID
+ * @param iconCid - The icon's IPFS CID (from node.icon). Pass empty/non-CID for emoji/letter icons.
+ * @returns iconUrl (object URL for img src) and isLoading
+ */
+export function useNodeIcon(
+  nodeId: string | undefined,
+  iconCid: string | undefined
+): UseNodeIconResult {
+  const [iconUrl, setIconUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const mountedRef = useRef(true);
+
+  // Only fetch if iconCid is a valid IPFS CID
+  const isIpfsCid = iconCid
+    ? iconCid.startsWith("Qm") || iconCid.startsWith("bafy")
+    : false;
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!nodeId || !iconCid || !isIpfsCid) {
+      setIconUrl(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchIcon = async () => {
+      setIsLoading(true);
+      try {
+        const url = await nodeIconManager.getIcon(nodeId, iconCid);
+        if (!cancelled && mountedRef.current) {
+          setIconUrl(url);
+        }
+      } catch (err) {
+        console.error("[useNodeIcon] Failed to fetch icon:", err);
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchIcon();
+
+    return () => {
+      cancelled = true;
+      mountedRef.current = false;
+    };
+  }, [nodeId, iconCid, isIpfsCid]);
+
+  return { iconUrl, isLoading };
+}

--- a/apps/desktop/src/hooks/usePresenceSubscriptions.ts
+++ b/apps/desktop/src/hooks/usePresenceSubscriptions.ts
@@ -5,6 +5,7 @@ import { useTransport } from "../providers/TransportProvider";
 import { useNodeStore } from "../stores/node-store";
 import { useSocialStore } from "../stores/social-store";
 import { useIdentityStore } from "../stores/identity-store";
+import { useAppVisibilityStore } from "./useAppVisibility";
 
 const OFFLINE_THRESHOLD = 60_000; // 60 seconds
 const STALENESS_CHECK_INTERVAL = 15_000; // Check every 15 seconds
@@ -23,6 +24,7 @@ export function usePresenceSubscriptions() {
   const activeNodeId = useNodeStore((s) => s.activeNodeId);
   const members = useNodeStore((s) => s.members);
   const friends = useSocialStore((s) => s.friends);
+  const isVisible = useAppVisibilityStore((s) => s.isVisible);
 
   // Memoize the member keys for the active node to avoid unnecessary re-renders
   const activeMemberKeys = useMemo(() => {
@@ -75,7 +77,7 @@ export function usePresenceSubscriptions() {
     // Clear lastSeen when node changes
     lastSeenRef.current.clear();
 
-    if (!isAuthenticated || !publicKey || !transport) return;
+    if (!isAuthenticated || !publicKey || !transport || !isVisible) return;
 
     // Collect public keys: node members + friends
     const publicKeySet = new Set<string>();
@@ -125,5 +127,5 @@ export function usePresenceSubscriptions() {
         stalenessIntervalRef.current = null;
       }
     };
-  }, [transport, isAuthenticated, publicKey, activeNodeId, activeMemberKeys, friends, updateMemberStatus]);
+  }, [transport, isAuthenticated, publicKey, activeNodeId, activeMemberKeys, friends, updateMemberStatus, isVisible]);
 }

--- a/apps/desktop/src/layouts/AppShell.tsx
+++ b/apps/desktop/src/layouts/AppShell.tsx
@@ -6,6 +6,8 @@ import { useDMStore } from "../stores/dm-store";
 import { useSocialStore } from "../stores/social-store";
 import { useVoiceStore } from "../stores/voice-store";
 import { useSearchStore } from "../stores/search-store";
+import { useRelayStore } from "../stores/relay-store";
+import { getHealthMonitor } from "../stores/relay-store";
 import { useNodeSubscriptions } from "../hooks/useNodeSubscriptions";
 import { useMemberSubscription } from "../hooks/useMemberSubscription";
 import { useChannelSubscription } from "../hooks/useChannelSubscription";
@@ -19,9 +21,11 @@ import { useGracefulShutdown } from "../hooks/useGracefulShutdown";
 import { useModerationEvents } from "../hooks/useModerationEvents";
 import { useDirectoryRefresh } from "../hooks/useDirectoryRefresh";
 import { useUpdater } from "../hooks/useUpdater";
+import { useAppVisibility, useAppVisibilityStore } from "../hooks/useAppVisibility";
 import { useTransport } from "../providers/TransportProvider";
 import { initNotificationManager } from "../services/notification-manager";
-import { migrateMemberRoles } from "@nodes/transport-gun";
+import { migrateMemberRoles, GunInstanceManager } from "@nodes/transport-gun";
+import type { GunConnectionMonitor } from "@nodes/transport-gun";
 import { NodeSidebar } from "./NodeSidebar";
 import { ChannelSidebar } from "./ChannelSidebar";
 import { MainContent } from "./MainContent";
@@ -56,8 +60,12 @@ export function AppShell() {
   const [showMembers, setShowMembers] = useState(true);
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
   
+  // App visibility / sleep-wake detection
+  useAppVisibility();
+  const isVisible = useAppVisibilityStore((s) => s.isVisible);
+  
   // Voice state for keyboard shortcuts
-  const { voice } = useTransport();
+  const { voice, connection } = useTransport();
   const voiceState = useVoiceStore((s) => s.state);
   
   // Search state
@@ -152,6 +160,40 @@ export function AppShell() {
   // Refresh directory listings for owned Nodes periodically
   useDirectoryRefresh();
 
+  // Pause/resume connection monitor and relay health when app visibility changes
+  useEffect(() => {
+    const monitor = connection as GunConnectionMonitor;
+    const healthMonitor = getHealthMonitor();
+    if (isVisible) {
+      monitor.resume?.();
+      healthMonitor?.resume?.();
+    } else {
+      monitor.pause?.();
+      healthMonitor?.pause?.();
+    }
+  }, [isVisible, connection]);
+
+  // Start relay health monitoring
+  const startRelayMonitoring = useRelayStore((s) => s.startMonitoring);
+  useEffect(() => {
+    if (isAuthenticated) {
+      const peers = GunInstanceManager.getPeers();
+      if (peers.length > 0) {
+        // On Tauri desktop, use native HTTP to bypass CORS for health checks
+        const isTauri = !!(window as any).__TAURI_INTERNALS__;
+        if (isTauri) {
+          import("@tauri-apps/plugin-http").then(({ fetch: tauriFetch }) => {
+            startRelayMonitoring(peers, tauriFetch as unknown as typeof fetch);
+          }).catch(() => {
+            startRelayMonitoring(peers);
+          });
+        } else {
+          startRelayMonitoring(peers);
+        }
+      }
+    }
+  }, [isAuthenticated, startRelayMonitoring]);
+
   // Load user's Nodes, DM conversations, and social data on mount
   useEffect(() => {
     if (isAuthenticated && publicKey) {
@@ -160,6 +202,7 @@ export function AppShell() {
         useDMStore.getState().loadConversations(),
         initializeSocial(publicKey),
         initNotificationManager(),
+        useVoiceStore.getState().loadSettings(),
       ]).then(() => {
         // Run member role migration for owned Nodes (fire-and-forget)
         // Only the owner's client writes, to avoid concurrent Gun write races

--- a/apps/desktop/src/layouts/ChannelSidebar.tsx
+++ b/apps/desktop/src/layouts/ChannelSidebar.tsx
@@ -8,6 +8,7 @@ import { ChannelListSkeleton } from "../components/ui";
 import { VoiceChannelEntry, VoiceConnectionBar } from "../components/voice";
 import { usePermissions, useCanViewChannel, useCanSendInChannel, useIsAdmin } from "../hooks/usePermissions";
 import { useVoiceTransport } from "../providers/TransportProvider";
+import { NodeIcon } from "../components/ui";
 
 /**
  * ChannelSidebar displays the channel list for the active Node.
@@ -84,9 +85,14 @@ export function ChannelSidebar() {
         onClick={() => setShowSettings(true)}
         className="h-12 px-4 flex items-center justify-between border-b border-surface-border hover:bg-surface-hover transition-colors"
       >
-        <span className="font-semibold text-nodes-text truncate">
-          {node.name}
-        </span>
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-6 h-6 rounded flex items-center justify-center overflow-hidden shrink-0">
+            <NodeIcon nodeId={node.id} icon={node.icon} name={node.name} size="sm" />
+          </div>
+          <span className="font-semibold text-nodes-text truncate">
+            {node.name}
+          </span>
+        </div>
         <svg
           className="w-4 h-4 text-nodes-text-muted shrink-0"
           fill="none"

--- a/apps/desktop/src/layouts/NodeSidebar.tsx
+++ b/apps/desktop/src/layouts/NodeSidebar.tsx
@@ -6,6 +6,7 @@ import { useNavigationStore } from "../stores/navigation-store";
 import { useDMStore } from "../stores/dm-store";
 import { useSocialStore } from "../stores/social-store";
 import { useNotificationStore } from "../stores/notification-store";
+import { NodeIcon } from "../components/ui";
 import { CreateNodeModal } from "../components/modals/CreateNodeModal";
 import { JoinNodeModal } from "../components/modals/JoinNodeModal";
 
@@ -72,7 +73,7 @@ export function NodeSidebar() {
 
       {/* Node icons */}
       {nodes.map((node) => (
-        <NodeIcon
+        <SidebarNodeIcon
           key={node.id}
           nodeId={node.id}
           icon={node.icon}
@@ -139,7 +140,7 @@ export function NodeSidebar() {
   );
 }
 
-interface NodeIconProps {
+interface SidebarNodeIconProps {
   nodeId: string;
   icon: string;
   name: string;
@@ -150,7 +151,11 @@ interface NodeIconProps {
 // Empty array constant to prevent re-renders from new array references
 const EMPTY_CHANNELS: Channel[] = [];
 
-function NodeIcon({ nodeId, icon, name, isActive, onClick }: NodeIconProps) {
+function isIpfsCid(value: string): boolean {
+  return value.startsWith("Qm") || value.startsWith("bafy");
+}
+
+function SidebarNodeIcon({ nodeId, icon, name, isActive, onClick }: SidebarNodeIconProps) {
   // Get channels for this node to sum mention counts
   const channelsMap = useNodeStore((s) => s.channels);
   const channels = channelsMap[nodeId] ?? EMPTY_CHANNELS;
@@ -160,8 +165,6 @@ function NodeIcon({ nodeId, icon, name, isActive, onClick }: NodeIconProps) {
   const totalMentions = channels.reduce((sum, channel) => {
     return sum + (mentionCounts[channel.id] || 0);
   }, 0);
-  
-  console.log("[NodeIcon] Rendering", name, "totalMentions:", totalMentions, "mentionCounts:", mentionCounts, "channels:", channels.map(c => c.id));
   
   // Generate a consistent color from the node name
   const colors = [
@@ -179,6 +182,8 @@ function NodeIcon({ nodeId, icon, name, isActive, onClick }: NodeIconProps) {
     colors.length;
   const bgColor = colors[colorIndex];
 
+  const hasCustomImage = icon && isIpfsCid(icon);
+
   return (
     <div className="relative group">
       {/* Active indicator */}
@@ -190,12 +195,14 @@ function NodeIcon({ nodeId, icon, name, isActive, onClick }: NodeIconProps) {
 
       <button
         onClick={onClick}
-        className={`w-12 h-12 flex items-center justify-center text-white text-lg font-semibold transition-all duration-200 ${bgColor} ${
+        className={`w-12 h-12 flex items-center justify-center text-white text-lg font-semibold transition-all duration-200 overflow-hidden ${
+          hasCustomImage ? "" : bgColor
+        } ${
           isActive ? "rounded-2xl" : "rounded-full hover:rounded-2xl"
         }`}
         title={name}
       >
-        {icon.length === 1 ? icon : icon.charAt(0)}
+        <NodeIcon nodeId={nodeId} icon={icon} name={name} size="md" />
       </button>
       
       {/* Mention badge */}

--- a/apps/desktop/src/layouts/StatusBar.tsx
+++ b/apps/desktop/src/layouts/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useIdentityStore } from "../stores/identity-store";
-import { ConnectionStatus, Badge, Avatar } from "../components/ui";
+import { ConnectionStatus, Badge, Avatar, RelayStatusIndicator } from "../components/ui";
 import { CopyablePublicKey } from "../components/ui/CopyablePublicKey";
 import { NotificationCenter } from "../components/notifications";
 import { getStatusColor } from "../utils/status";
@@ -26,7 +26,10 @@ export function StatusBar({ onOpenSettings, onOpenProfile, updateAvailable }: St
 
   return (
     <div className="h-8 bg-nodes-surface border-t border-nodes-border flex items-center justify-between px-4 text-xs shrink-0">
-      <ConnectionStatus />
+      <div className="flex items-center gap-3">
+        <ConnectionStatus />
+        <RelayStatusIndicator />
+      </div>
       <div className="flex items-center gap-3">
         {/* Clickable profile avatar and name */}
         <button

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { getSearchIndex } from "./services/search-index";
 import { ThemeEngine } from "./services/theme-engine";
-import { configureAvatarManager, configureFileTransport } from "@nodes/transport-gun";
+import { configureAvatarManager, configureFileTransport, configureNodeIconManager } from "@nodes/transport-gun";
 
 // Detect if running in Tauri
 const isTauri = !!(window as any).__TAURI_INTERNALS__;
@@ -25,6 +25,11 @@ if (isTauri) {
       ipfsApiUrl: import.meta.env.VITE_IPFS_API_URL,
       serverPinFetch: tauriFetch as unknown as typeof fetch,
     });
+    configureNodeIconManager({
+      ipfsApiUrl: import.meta.env.VITE_IPFS_API_URL,
+      ipfsGatewayUrl: import.meta.env.VITE_IPFS_GATEWAY_URL,
+      serverPinFetch: tauriFetch as unknown as typeof fetch,
+    });
   });
 } else {
   // Web: use regular fetch for server pinning
@@ -34,6 +39,10 @@ if (isTauri) {
   });
   configureFileTransport({
     ipfsApiUrl: import.meta.env.VITE_IPFS_API_URL,
+  });
+  configureNodeIconManager({
+    ipfsApiUrl: import.meta.env.VITE_IPFS_API_URL,
+    ipfsGatewayUrl: import.meta.env.VITE_IPFS_GATEWAY_URL,
   });
 }
 

--- a/apps/desktop/src/services/app-cache.ts
+++ b/apps/desktop/src/services/app-cache.ts
@@ -1,0 +1,259 @@
+/**
+ * App-level IndexedDB cache for fast startup.
+ * 
+ * Stores frequently accessed data (messages, channels, members, etc.)
+ * so the app can render immediately from cache while syncing from Gun.
+ * 
+ * Pattern: Cache-first, network-update
+ * 1. Read from IndexedDB (instant)
+ * 2. Render cached data
+ * 3. Fetch from Gun (background)
+ * 4. Update cache with fresh data
+ */
+
+const DB_NAME = "nodes-app-cache";
+const DB_VERSION = 1;
+const STORE_NAME = "cache";
+
+// Cache schema version - bump this to invalidate all cached data
+const CACHE_SCHEMA_VERSION = 1;
+
+let db: IDBDatabase | null = null;
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  version: number;
+}
+
+async function openDb(): Promise<IDBDatabase> {
+  if (db) return db;
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      console.error("[AppCache] Failed to open database:", request.error);
+      dbPromise = null;
+      reject(request.error);
+    };
+
+    request.onsuccess = () => {
+      db = request.result;
+      resolve(db);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const database = (event.target as IDBOpenDBRequest).result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME);
+      }
+    };
+  });
+
+  return dbPromise;
+}
+
+/**
+ * Get cached data by key.
+ * Returns null if not found or on error.
+ */
+export async function getCache<T>(key: string): Promise<T | null> {
+  try {
+    const database = await openDb();
+    return new Promise((resolve) => {
+      const tx = database.transaction(STORE_NAME, "readonly");
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.get(key);
+
+      request.onerror = () => {
+        console.warn("[AppCache] Failed to read:", key, request.error);
+        resolve(null);
+      };
+
+      request.onsuccess = () => {
+        const entry = request.result as CacheEntry<T> | undefined;
+        if (!entry) {
+          resolve(null);
+          return;
+        }
+
+        // Invalidate if schema version changed
+        if (entry.version !== CACHE_SCHEMA_VERSION) {
+          resolve(null);
+          return;
+        }
+
+        resolve(entry.data);
+      };
+    });
+  } catch (err) {
+    console.warn("[AppCache] Error reading cache:", err);
+    return null;
+  }
+}
+
+/**
+ * Set cached data by key.
+ */
+export async function setCache<T>(key: string, data: T): Promise<void> {
+  try {
+    const database = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = database.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+
+      const entry: CacheEntry<T> = {
+        data,
+        timestamp: Date.now(),
+        version: CACHE_SCHEMA_VERSION,
+      };
+
+      const request = store.put(entry, key);
+
+      request.onerror = () => {
+        console.warn("[AppCache] Failed to write:", key, request.error);
+        reject(request.error);
+      };
+
+      request.onsuccess = () => resolve();
+    });
+  } catch (err) {
+    console.warn("[AppCache] Error writing cache:", err);
+  }
+}
+
+/**
+ * Delete a specific cache entry.
+ */
+export async function deleteCache(key: string): Promise<void> {
+  try {
+    const database = await openDb();
+    return new Promise((resolve) => {
+      const tx = database.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.delete(key);
+
+      request.onerror = () => {
+        console.warn("[AppCache] Failed to delete:", key, request.error);
+        resolve();
+      };
+
+      request.onsuccess = () => resolve();
+    });
+  } catch (err) {
+    console.warn("[AppCache] Error deleting cache:", err);
+  }
+}
+
+/**
+ * Clear all cached data.
+ * Call on logout or identity switch.
+ */
+export async function clearCache(): Promise<void> {
+  try {
+    const database = await openDb();
+    return new Promise((resolve) => {
+      const tx = database.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.clear();
+
+      request.onerror = () => {
+        console.warn("[AppCache] Failed to clear:", request.error);
+        resolve();
+      };
+
+      request.onsuccess = () => {
+        console.log("[AppCache] Cache cleared");
+        resolve();
+      };
+    });
+  } catch (err) {
+    console.warn("[AppCache] Error clearing cache:", err);
+  }
+}
+
+/**
+ * Get cache entry with metadata (timestamp).
+ * Useful for checking staleness.
+ */
+export async function getCacheWithMeta<T>(
+  key: string
+): Promise<{ data: T; timestamp: number } | null> {
+  try {
+    const database = await openDb();
+    return new Promise((resolve) => {
+      const tx = database.transaction(STORE_NAME, "readonly");
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.get(key);
+
+      request.onerror = () => {
+        resolve(null);
+      };
+
+      request.onsuccess = () => {
+        const entry = request.result as CacheEntry<T> | undefined;
+        if (!entry || entry.version !== CACHE_SCHEMA_VERSION) {
+          resolve(null);
+          return;
+        }
+        resolve({ data: entry.data, timestamp: entry.timestamp });
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if cached data is stale (older than TTL).
+ */
+export async function isCacheStale(key: string, ttlMs: number): Promise<boolean> {
+  const meta = await getCacheWithMeta(key);
+  if (!meta) return true;
+  return Date.now() - meta.timestamp > ttlMs;
+}
+
+// ============================================
+// Cache key helpers
+// ============================================
+
+export const CacheKeys = {
+  // Nodes the user belongs to
+  userNodes: () => "user-nodes",
+  
+  // Channels for a specific Node
+  channels: (nodeId: string) => `channels:${nodeId}`,
+  
+  // Members for a specific Node
+  members: (nodeId: string) => `members:${nodeId}`,
+  
+  // Messages for a specific channel (capped at 100)
+  messages: (channelId: string) => `messages:${channelId}`,
+  
+  // DM conversations list
+  dmConversations: () => "dm-conversations",
+  
+  // DM messages for a conversation (capped at 100)
+  dmMessages: (conversationId: string) => `dm-messages:${conversationId}`,
+  
+  // Display name cache
+  displayNames: () => "display-names",
+  
+  // Reactions for a message
+  reactions: (messageId: string) => `reactions:${messageId}`,
+  
+  // Friends list
+  friends: () => "friends",
+  
+  // Blocked users list
+  blockedUsers: () => "blocked-users",
+  
+  // Voice/audio settings
+  voiceSettings: () => "voice-settings",
+};
+
+// Maximum messages to cache per channel
+export const MAX_CACHED_MESSAGES = 100;

--- a/apps/desktop/src/stores/dm-store.ts
+++ b/apps/desktop/src/stores/dm-store.ts
@@ -8,6 +8,7 @@ import { useToastStore } from "./toast-store";
 import { useSocialStore } from "./social-store";
 import { useIdentityStore } from "./identity-store";
 import { useNavigationStore } from "./navigation-store";
+import { getCache, setCache, CacheKeys } from "../services/app-cache";
 
 interface DMState {
   // State
@@ -52,6 +53,18 @@ interface DMState {
 
 const dmManager = new DMManager();
 
+// Debounced DM message cache save (per conversation)
+const dmCacheSaveTimeouts: Record<string, ReturnType<typeof setTimeout>> = {};
+function saveDMMessagesToCache(conversationId: string, messages: TransportMessage[]): void {
+  if (dmCacheSaveTimeouts[conversationId]) {
+    clearTimeout(dmCacheSaveTimeouts[conversationId]);
+  }
+  dmCacheSaveTimeouts[conversationId] = setTimeout(async () => {
+    const toCache = messages.slice(-100); // Keep last 100
+    await setCache(CacheKeys.dmMessages(conversationId), toCache);
+  }, 1000); // Debounce 1 second
+}
+
 export const useDMStore = create<DMState>((set, get) => ({
   conversations: [],
   activeConversationId: null,
@@ -64,8 +77,16 @@ export const useDMStore = create<DMState>((set, get) => ({
   activeTypingSub: null,
 
   loadConversations: async () => {
-    set({ isLoading: true });
+    // 1. Load from IndexedDB cache first (instant render)
+    const cached = await getCache<DMConversation[]>(CacheKeys.dmConversations());
+    if (cached && cached.length > 0) {
+      set({ conversations: cached, isLoading: false });
+    } else {
+      set({ isLoading: true });
+    }
+
     try {
+      // 2. Fetch from Gun (network)
       const newConversations = await dmManager.getConversations();
       
       // Merge with existing conversations to preserve preview data
@@ -102,6 +123,9 @@ export const useDMStore = create<DMState>((set, get) => ({
         return { conversations: deduped, isLoading: false };
 
       });
+
+      // 3. Save to cache
+      await setCache(CacheKeys.dmConversations(), get().conversations);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Unknown error";
       useToastStore.getState().addToast("error", `Failed to load DMs: ${message}`);
@@ -173,17 +197,29 @@ export const useDMStore = create<DMState>((set, get) => ({
 
     if (!conversationId || !recipientKey || !keypair) return;
 
-    set({ isLoading: true });
+    // 1. Load from IndexedDB cache first (instant render)
+    const cached = await getCache<TransportMessage[]>(CacheKeys.dmMessages(conversationId));
+    if (cached && cached.length > 0) {
+      set((state) => ({
+        messages: { ...state.messages, [conversationId]: cached },
+      }));
+    } else {
+      set({ isLoading: true });
+    }
 
     try {
       const epub = await get().resolveEpub(recipientKey);
 
-      // Load history
+      // 2. Load history from Gun (network)
       const history = await dmManager.getHistory(conversationId, epub, keypair, 50);
       set((state) => ({
         messages: { ...state.messages, [conversationId]: history },
         isLoading: false,
       }));
+
+      // 3. Save to cache (last 100 messages)
+      const toCache = history.slice(-100);
+      await setCache(CacheKeys.dmMessages(conversationId), toCache);
 
       // Subscribe to new messages
       const messageSub = dmManager.subscribe(
@@ -298,12 +334,17 @@ export const useDMStore = create<DMState>((set, get) => ({
           : c
       );
 
+      const newMessages = [...existing, message].sort(
+        (a, b) => a.timestamp - b.timestamp
+      );
+
+      // Save to IndexedDB cache (debounced)
+      saveDMMessagesToCache(conversationId, newMessages);
+
       return {
         messages: {
           ...state.messages,
-          [conversationId]: [...existing, message].sort(
-            (a, b) => a.timestamp - b.timestamp
-          ),
+          [conversationId]: newMessages,
         },
         conversations: updatedConversations,
       };
@@ -393,6 +434,8 @@ export const useDMStore = create<DMState>((set, get) => ({
         conversations: [conversation, ...state.conversations],
       };
     });
+    // Update cache (fire and forget)
+    setCache(CacheKeys.dmConversations(), get().conversations);
   },
 
   cleanup: () => {

--- a/apps/desktop/src/stores/identity-store.ts
+++ b/apps/desktop/src/stores/identity-store.ts
@@ -20,6 +20,9 @@ import { useMessageStore } from "./message-store";
 import { useNavigationStore } from "./navigation-store";
 import { useSearchStore } from "./search-store";
 import { useDiscoveryStore } from "./discovery-store";
+import { useRelayStore } from "./relay-store";
+import { clearCache } from "../services/app-cache";
+import { nodeIconManager } from "@nodes/transport-gun";
 
 interface IdentityState {
   // State
@@ -235,8 +238,15 @@ export const useIdentityStore = create<IdentityState>((set, get) => ({
     useNavigationStore.getState().reset();
     useSearchStore.getState().reset();
     useDiscoveryStore.getState().reset();
+    useRelayStore.getState().reset();
 
-    // 3. Clear identity
+    // 3. Clear IndexedDB cache
+    await clearCache();
+
+    // 4. Clear node icon memory cache
+    nodeIconManager.clearCache();
+
+    // 5. Clear identity
     keyManager.logout();
     set({
       isAuthenticated: false,
@@ -362,8 +372,15 @@ export const useIdentityStore = create<IdentityState>((set, get) => ({
     useNavigationStore.getState().reset();
     useSearchStore.getState().reset();
     useDiscoveryStore.getState().reset();
+    useRelayStore.getState().reset();
 
-    // 4. Clear identity
+    // 4. Clear IndexedDB cache
+    await clearCache();
+
+    // Clear node icon memory cache
+    nodeIconManager.clearCache();
+
+    // 5. Clear identity
     keyManager.logout();
 
     set({

--- a/apps/desktop/src/stores/message-store.ts
+++ b/apps/desktop/src/stores/message-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { TransportMessage, Unsubscribe } from "@nodes/transport";
+import { getCache, setCache, CacheKeys, MAX_CACHED_MESSAGES } from "../services/app-cache";
 
 interface MessageState {
   // Messages keyed by channelId
@@ -31,6 +32,11 @@ interface MessageState {
   clearUnread: (channelId: string) => void;
   clearChannel: (channelId: string) => void;
   clearAllChannels: () => void;
+  
+  // Cache actions
+  loadFromCache: (channelId: string) => Promise<boolean>; // Returns true if cache hit
+  saveToCache: (channelId: string) => Promise<void>;
+  
   reset: () => void;
 }
 
@@ -237,6 +243,26 @@ export const useMessageStore = create<MessageState>((set, get) => ({
       activeSubscription: null,
       activeTypingSub: null,
     });
+  },
+
+  loadFromCache: async (channelId) => {
+    const cached = await getCache<TransportMessage[]>(CacheKeys.messages(channelId));
+    if (cached && cached.length > 0) {
+      set((state) => ({
+        messages: { ...state.messages, [channelId]: cached },
+      }));
+      return true;
+    }
+    return false;
+  },
+
+  saveToCache: async (channelId) => {
+    const messages = get().messages[channelId];
+    if (!messages || messages.length === 0) return;
+    
+    // Only cache the last N messages to keep cache size manageable
+    const toCache = messages.slice(-MAX_CACHED_MESSAGES);
+    await setCache(CacheKeys.messages(channelId), toCache);
   },
 
   reset: () => {

--- a/apps/desktop/src/stores/node-store.ts
+++ b/apps/desktop/src/stores/node-store.ts
@@ -6,6 +6,7 @@ import { useNotificationStore } from "./notification-store";
 import { useMessageStore } from "./message-store";
 import { useThemeStore } from "./theme-store";
 import { useRoleStore } from "./role-store";
+import { getCache, setCache, CacheKeys } from "../services/app-cache";
 
 // TTL for cached display names (5 minutes)
 const DISPLAY_NAME_CACHE_TTL = 5 * 60 * 1000;
@@ -96,10 +97,25 @@ export const useNodeStore = create<NodeState>((set, get) => ({
   displayNameCache: {},
 
   loadUserNodes: async () => {
-    set({ isLoadingNodes: true });
+    // 1. Load from IndexedDB cache first (instant render)
+    const cached = await getCache<NodeServer[]>(CacheKeys.userNodes());
+    if (cached && cached.length > 0) {
+      set({ nodes: cached, isLoadingNodes: false });
+      // If we have cached nodes but no active one, select the first
+      if (!get().activeNodeId) {
+        get().setActiveNode(cached[0].id);
+      }
+    } else {
+      set({ isLoadingNodes: true });
+    }
+
     try {
+      // 2. Fetch from Gun (network)
       const nodes = await nodeManager.getUserNodes();
       set({ nodes, isLoadingNodes: false });
+
+      // 3. Save to cache
+      await setCache(CacheKeys.userNodes(), nodes);
 
       // If we have nodes but no active one, select the first
       if (nodes.length > 0 && !get().activeNodeId) {
@@ -120,6 +136,9 @@ export const useNodeStore = create<NodeState>((set, get) => ({
         nodes: [...state.nodes, node],
         isCreatingNode: false,
       }));
+
+      // Update cache
+      await setCache(CacheKeys.userNodes(), get().nodes);
 
       // Auto-select the new Node
       get().setActiveNode(node.id);
@@ -147,6 +166,9 @@ export const useNodeStore = create<NodeState>((set, get) => ({
           : [...state.nodes, node],
         isJoiningNode: false,
       }));
+
+      // Update cache
+      await setCache(CacheKeys.userNodes(), get().nodes);
 
       get().setActiveNode(node.id);
 
@@ -191,6 +213,8 @@ export const useNodeStore = create<NodeState>((set, get) => ({
         return newMembers;
       })(),
     }));
+    // Update cache (fire and forget)
+    setCache(CacheKeys.userNodes(), get().nodes);
   },
 
   deleteNode: async (nodeId) => {
@@ -310,8 +334,20 @@ export const useNodeStore = create<NodeState>((set, get) => ({
   },
 
   loadChannels: async (nodeId) => {
-    // Mark as loading (only if not already cached)
-    const hasCached = (get().channels[nodeId]?.length ?? 0) > 0;
+    // 1. Load from IndexedDB cache first (instant render)
+    const cached = await getCache<NodeChannel[]>(CacheKeys.channels(nodeId));
+    if (cached && cached.length > 0) {
+      set((state) => ({
+        channels: { ...state.channels, [nodeId]: cached },
+      }));
+      // Set active channel from cache immediately
+      if (get().activeNodeId === nodeId) {
+        set({ activeChannelId: pickChannelId(get().activeChannelByNode[nodeId], cached) });
+      }
+    }
+
+    // Mark as loading (only if not already cached in memory or IndexedDB)
+    const hasCached = cached || (get().channels[nodeId]?.length ?? 0) > 0;
     if (!hasCached) {
       set((state) => ({
         loadingChannels: { ...state.loadingChannels, [nodeId]: true },
@@ -319,11 +355,15 @@ export const useNodeStore = create<NodeState>((set, get) => ({
     }
 
     try {
+      // 2. Fetch from Gun (network)
       const channels = await nodeManager.getChannels(nodeId);
       set((state) => ({
         channels: { ...state.channels, [nodeId]: channels },
         loadingChannels: { ...state.loadingChannels, [nodeId]: false },
       }));
+
+      // 3. Save to cache
+      await setCache(CacheKeys.channels(nodeId), channels);
 
       // If this is the active node, set the active channel to the last-visited or first channel
       if (get().activeNodeId === nodeId && channels.length > 0) {
@@ -359,10 +399,22 @@ export const useNodeStore = create<NodeState>((set, get) => ({
 
   loadMembers: async (nodeId) => {
     try {
+      // 1. Load from IndexedDB cache first (instant render)
+      const cached = await getCache<NodeMember[]>(CacheKeys.members(nodeId));
+      if (cached && cached.length > 0) {
+        set((state) => ({
+          members: { ...state.members, [nodeId]: cached },
+        }));
+      }
+
+      // 2. Fetch from Gun (network)
       const members = await nodeManager.getMembers(nodeId);
       set((state) => ({
         members: { ...state.members, [nodeId]: members },
       }));
+
+      // 3. Save to cache
+      await setCache(CacheKeys.members(nodeId), members);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Unknown error";
       useToastStore.getState().addToast("error", `Failed to load members: ${message}`);
@@ -376,6 +428,8 @@ export const useNodeStore = create<NodeState>((set, get) => ({
       set((state) => ({
         members: { ...state.members, [nodeId]: members },
       }));
+      // Update cache with fresh data
+      await setCache(CacheKeys.members(nodeId), members);
     } catch (err: unknown) {
       // Silent fail for refresh - don't spam user with errors
       console.error("Failed to refresh members:", err);

--- a/apps/desktop/src/stores/relay-store.ts
+++ b/apps/desktop/src/stores/relay-store.ts
@@ -1,0 +1,159 @@
+import { create } from "zustand";
+import { RelayHealthMonitor } from "@nodes/transport-gun";
+import type { RelayStatus } from "@nodes/transport-gun";
+
+const CUSTOM_RELAYS_KEY = "nodes_custom_relays";
+
+interface RelayState {
+  // State
+  relays: RelayStatus[];
+  connectedCount: number;
+  totalCount: number;
+  customRelays: string[];
+  isMonitoring: boolean;
+
+  // Actions
+  startMonitoring: (urls: string[], customFetch?: typeof fetch) => void;
+  stopMonitoring: () => void;
+  addCustomRelay: (url: string) => void;
+  removeCustomRelay: (url: string) => void;
+  getCustomRelays: () => string[];
+  reset: () => void;
+}
+
+// Singleton health monitor instance
+let healthMonitor: RelayHealthMonitor | null = null;
+
+export const useRelayStore = create<RelayState>((set, get) => ({
+  relays: [],
+  connectedCount: 0,
+  totalCount: 0,
+  customRelays: [],
+  isMonitoring: false,
+
+  startMonitoring: (urls: string[], customFetch?: typeof fetch) => {
+    // Load custom relays from localStorage
+    const stored = localStorage.getItem(CUSTOM_RELAYS_KEY);
+    const customRelays: string[] = stored ? JSON.parse(stored) : [];
+    
+    // Combine default relays with custom relays
+    const allRelays = [...new Set([...urls, ...customRelays])];
+    
+    // Stop existing monitor if running
+    if (healthMonitor) {
+      healthMonitor.stop();
+    }
+
+    // Create new monitor
+    healthMonitor = new RelayHealthMonitor();
+    
+    // Subscribe to status changes
+    healthMonitor.onStatusChange((statuses) => {
+      set({
+        relays: statuses,
+        connectedCount: statuses.filter((r) => r.connected).length,
+        totalCount: statuses.length,
+      });
+    });
+
+    // Start monitoring
+    healthMonitor.start(allRelays, undefined, customFetch);
+    
+    set({
+      customRelays,
+      totalCount: allRelays.length,
+      isMonitoring: true,
+    });
+  },
+
+  stopMonitoring: () => {
+    if (healthMonitor) {
+      healthMonitor.stop();
+      healthMonitor = null;
+    }
+    set({ isMonitoring: false });
+  },
+
+  addCustomRelay: (url: string) => {
+    const { customRelays, relays } = get();
+    
+    // Validate URL format
+    if (!url.startsWith("wss://") && !url.startsWith("ws://")) {
+      throw new Error("Relay URL must start with wss:// or ws://");
+    }
+    
+    // Check for duplicates
+    if (customRelays.includes(url) || relays.some((r) => r.url === url)) {
+      throw new Error("Relay already exists");
+    }
+    
+    const newCustomRelays = [...customRelays, url];
+    localStorage.setItem(CUSTOM_RELAYS_KEY, JSON.stringify(newCustomRelays));
+    
+    // Add to monitoring if active
+    if (healthMonitor) {
+      // Restart monitoring with new relay list
+      const allUrls = [...relays.map((r) => r.url), url];
+      healthMonitor.stop();
+      healthMonitor = new RelayHealthMonitor();
+      healthMonitor.onStatusChange((statuses) => {
+        set({
+          relays: statuses,
+          connectedCount: statuses.filter((r) => r.connected).length,
+          totalCount: statuses.length,
+        });
+      });
+      healthMonitor.start(allUrls);
+    }
+    
+    set({ customRelays: newCustomRelays });
+  },
+
+  removeCustomRelay: (url: string) => {
+    const { customRelays, relays } = get();
+    
+    const newCustomRelays = customRelays.filter((r) => r !== url);
+    localStorage.setItem(CUSTOM_RELAYS_KEY, JSON.stringify(newCustomRelays));
+    
+    // Restart monitoring without removed relay
+    if (healthMonitor) {
+      const remainingUrls = relays.map((r) => r.url).filter((u) => u !== url);
+      healthMonitor.stop();
+      healthMonitor = new RelayHealthMonitor();
+      healthMonitor.onStatusChange((statuses) => {
+        set({
+          relays: statuses,
+          connectedCount: statuses.filter((r) => r.connected).length,
+          totalCount: statuses.length,
+        });
+      });
+      healthMonitor.start(remainingUrls);
+    }
+    
+    set({ customRelays: newCustomRelays });
+  },
+
+  getCustomRelays: () => {
+    const stored = localStorage.getItem(CUSTOM_RELAYS_KEY);
+    return stored ? JSON.parse(stored) : [];
+  },
+
+  reset: () => {
+    if (healthMonitor) {
+      healthMonitor.stop();
+      healthMonitor = null;
+    }
+    set({
+      relays: [],
+      connectedCount: 0,
+      totalCount: 0,
+      customRelays: [],
+      isMonitoring: false,
+    });
+  },
+}));
+
+// Export for direct access to health monitor instance
+export function getHealthMonitor(): RelayHealthMonitor | null {
+  return healthMonitor;
+}

--- a/apps/desktop/src/stores/social-store.ts
+++ b/apps/desktop/src/stores/social-store.ts
@@ -4,6 +4,7 @@ import type { FriendRequest, Friend, BlockedUser } from "@nodes/core";
 import type { Unsubscribe } from "@nodes/transport";
 import { useToastStore } from "./toast-store";
 import { processFriendRequestNotification } from "../services/notification-manager";
+import { getCache, setCache, CacheKeys } from "../services/app-cache";
 
 const profileManager = new ProfileManager();
 
@@ -44,6 +45,24 @@ interface SocialState {
 
 const socialManager = new SocialManager();
 
+// Debounced cache saves for friends and blocked users
+let friendsCacheSaveTimeout: ReturnType<typeof setTimeout> | null = null;
+let blockedCacheSaveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function saveFriendsToCache(friends: Friend[]): void {
+  if (friendsCacheSaveTimeout) clearTimeout(friendsCacheSaveTimeout);
+  friendsCacheSaveTimeout = setTimeout(() => {
+    setCache(CacheKeys.friends(), friends).catch(() => {});
+  }, 500);
+}
+
+function saveBlockedUsersToCache(blockedUsers: BlockedUser[]): void {
+  if (blockedCacheSaveTimeout) clearTimeout(blockedCacheSaveTimeout);
+  blockedCacheSaveTimeout = setTimeout(() => {
+    setCache(CacheKeys.blockedUsers(), blockedUsers).catch(() => {});
+  }, 500);
+}
+
 export const useSocialStore = create<SocialState>((set, get) => ({
   friends: [],
   incomingRequests: [],
@@ -73,10 +92,26 @@ export const useSocialStore = create<SocialState>((set, get) => ({
     state.cancelledSub?.();
     state.declinedSub?.();
 
-    set({ isLoading: true });
+    // 1. Load from IndexedDB cache first (instant render)
+    const [cachedFriends, cachedBlockedUsers] = await Promise.all([
+      getCache<Friend[]>(CacheKeys.friends()),
+      getCache<BlockedUser[]>(CacheKeys.blockedUsers()),
+    ]);
+    
+    if (cachedFriends && cachedFriends.length > 0) {
+      set({ friends: cachedFriends.filter((f) => f.publicKey !== myKey) });
+    }
+    if (cachedBlockedUsers && cachedBlockedUsers.length > 0) {
+      set({ blockedUsers: cachedBlockedUsers });
+    }
+    
+    // Only show loading if no cache
+    if (!cachedFriends && !cachedBlockedUsers) {
+      set({ isLoading: true });
+    }
 
     try {
-      // Load initial data
+      // 2. Load from Gun (network)
       const [friendsRaw, blockedUsers, outgoingRequests] = await Promise.all([
         socialManager.getFriends(),
         socialManager.getBlockedUsers(),
@@ -87,6 +122,12 @@ export const useSocialStore = create<SocialState>((set, get) => ({
       const friends = friendsRaw.filter((f) => f.publicKey !== myKey);
 
       set({ friends, blockedUsers, outgoingRequests });
+
+      // 3. Save to cache
+      await Promise.all([
+        setCache(CacheKeys.friends(), friends),
+        setCache(CacheKeys.blockedUsers(), blockedUsers),
+      ]);
 
       // Subscribe to friends list changes
       const friendsSub = socialManager.subscribeFriends((friend, publicKey) => {
@@ -114,6 +155,8 @@ export const useSocialStore = create<SocialState>((set, get) => ({
           }
           return { friends: [...state.friends, friend] };
         });
+        // Update cache
+        saveFriendsToCache(get().friends);
       });
 
       // Subscribe to outgoing request status changes
@@ -200,6 +243,9 @@ export const useSocialStore = create<SocialState>((set, get) => ({
             friends: state.friends.filter((f) => f.publicKey !== fromKey),
           }));
           
+          // Update cache
+          saveFriendsToCache(get().friends);
+          
           // ALSO remove from our Gun graph so it doesn't come back on reload
           await socialManager.removeFriendFromGraph(fromKey);
           
@@ -228,6 +274,8 @@ export const useSocialStore = create<SocialState>((set, get) => ({
           set((state) => ({
             friends: [...state.friends, { publicKey: acceptorKey, addedAt: Date.now() }],
           }));
+          // Update cache
+          saveFriendsToCache(get().friends);
         }
         
         // Remove from outgoing requests
@@ -394,6 +442,9 @@ export const useSocialStore = create<SocialState>((set, get) => ({
       set((state) => ({
         friends: state.friends.filter((f) => f.publicKey !== publicKey),
       }));
+      
+      // Update cache
+      saveFriendsToCache(get().friends);
 
       useToastStore.getState().addToast("info", "Friend removed.");
     } catch (err: unknown) {
@@ -419,6 +470,10 @@ export const useSocialStore = create<SocialState>((set, get) => ({
           (r) => r.toKey !== publicKey
         ),
       }));
+      
+      // Update caches
+      saveFriendsToCache(get().friends);
+      saveBlockedUsersToCache(get().blockedUsers);
 
       useToastStore.getState().addToast("info", "User blocked.");
     } catch (err: unknown) {
@@ -434,6 +489,9 @@ export const useSocialStore = create<SocialState>((set, get) => ({
       set((state) => ({
         blockedUsers: state.blockedUsers.filter((b) => b.publicKey !== publicKey),
       }));
+      
+      // Update cache
+      saveBlockedUsersToCache(get().blockedUsers);
 
       useToastStore.getState().addToast("info", "User unblocked.");
     } catch (err: unknown) {

--- a/apps/desktop/src/stores/voice-store.ts
+++ b/apps/desktop/src/stores/voice-store.ts
@@ -1,5 +1,28 @@
 import { create } from "zustand";
 import type { VoiceState, VoiceParticipant, NodeVoiceConfig } from "@nodes/core";
+import { getCache, setCache, CacheKeys } from "../services/app-cache";
+
+/** The subset of voice store state that should persist across restarts. */
+interface VoiceSettings {
+  inputDeviceId: string | null;
+  outputDeviceId: string | null;
+  inputVolume: number;
+  pushToTalk: boolean;
+  pushToTalkKey: string | null;
+  noiseSuppression: boolean;
+  echoCancellation: boolean;
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function saveSettingsDebounced(settings: VoiceSettings) {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    setCache(CacheKeys.voiceSettings(), settings).catch((err) =>
+      console.warn("[VoiceStore] Failed to save settings:", err)
+    );
+  }, 500);
+}
 
 interface VoiceStore {
   // Current voice connection state
@@ -34,6 +57,9 @@ interface VoiceStore {
   // Participant helpers
   updateParticipantSpeaking: (publicKey: string, speaking: boolean) => void;
   
+  // Persistence
+  loadSettings: () => Promise<void>;
+  
   // Reset state on disconnect
   reset: () => void;
 }
@@ -67,26 +93,67 @@ export const useVoiceStore = create<VoiceStore>((set) => ({
   
   setNodeConfig: (config) => set({ nodeConfig: config }),
   
-  setInputDevice: (deviceId) => set({ inputDeviceId: deviceId }),
+  setInputDevice: (deviceId) => {
+    set({ inputDeviceId: deviceId });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: deviceId, outputDeviceId: s.outputDeviceId, inputVolume: s.inputVolume, pushToTalk: s.pushToTalk, pushToTalkKey: s.pushToTalkKey, noiseSuppression: s.noiseSuppression, echoCancellation: s.echoCancellation });
+  },
   
-  setOutputDevice: (deviceId) => set({ outputDeviceId: deviceId }),
+  setOutputDevice: (deviceId) => {
+    set({ outputDeviceId: deviceId });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: s.inputDeviceId, outputDeviceId: deviceId, inputVolume: s.inputVolume, pushToTalk: s.pushToTalk, pushToTalkKey: s.pushToTalkKey, noiseSuppression: s.noiseSuppression, echoCancellation: s.echoCancellation });
+  },
   
-  setInputVolume: (volume) => set({ inputVolume: Math.max(0, Math.min(100, volume)) }),
+  setInputVolume: (volume) => {
+    const clamped = Math.max(0, Math.min(100, volume));
+    set({ inputVolume: clamped });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: s.inputDeviceId, outputDeviceId: s.outputDeviceId, inputVolume: clamped, pushToTalk: s.pushToTalk, pushToTalkKey: s.pushToTalkKey, noiseSuppression: s.noiseSuppression, echoCancellation: s.echoCancellation });
+  },
   
-  setPushToTalk: (enabled, key) => set({ 
-    pushToTalk: enabled, 
-    pushToTalkKey: key ?? null 
-  }),
+  setPushToTalk: (enabled, key) => {
+    set({ pushToTalk: enabled, pushToTalkKey: key ?? null });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: s.inputDeviceId, outputDeviceId: s.outputDeviceId, inputVolume: s.inputVolume, pushToTalk: enabled, pushToTalkKey: key ?? null, noiseSuppression: s.noiseSuppression, echoCancellation: s.echoCancellation });
+  },
   
-  setNoiseSuppression: (enabled) => set({ noiseSuppression: enabled }),
+  setNoiseSuppression: (enabled) => {
+    set({ noiseSuppression: enabled });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: s.inputDeviceId, outputDeviceId: s.outputDeviceId, inputVolume: s.inputVolume, pushToTalk: s.pushToTalk, pushToTalkKey: s.pushToTalkKey, noiseSuppression: enabled, echoCancellation: s.echoCancellation });
+  },
   
-  setEchoCancellation: (enabled) => set({ echoCancellation: enabled }),
+  setEchoCancellation: (enabled) => {
+    set({ echoCancellation: enabled });
+    const s = useVoiceStore.getState();
+    saveSettingsDebounced({ inputDeviceId: s.inputDeviceId, outputDeviceId: s.outputDeviceId, inputVolume: s.inputVolume, pushToTalk: s.pushToTalk, pushToTalkKey: s.pushToTalkKey, noiseSuppression: s.noiseSuppression, echoCancellation: enabled });
+  },
   
   updateParticipantSpeaking: (publicKey, speaking) => set((state) => ({
     participants: state.participants.map((p) =>
       p.publicKey === publicKey ? { ...p, speaking } : p
     ),
   })),
+  
+  loadSettings: async () => {
+    try {
+      const saved = await getCache<VoiceSettings>(CacheKeys.voiceSettings());
+      if (saved) {
+        set({
+          inputDeviceId: saved.inputDeviceId,
+          outputDeviceId: saved.outputDeviceId,
+          inputVolume: saved.inputVolume,
+          pushToTalk: saved.pushToTalk,
+          pushToTalkKey: saved.pushToTalkKey,
+          noiseSuppression: saved.noiseSuppression,
+          echoCancellation: saved.echoCancellation,
+        });
+      }
+    } catch (err) {
+      console.warn("[VoiceStore] Failed to load settings:", err);
+    }
+  },
   
   reset: () => set({
     state: DEFAULT_STATE,

--- a/apps/desktop/src/utils/image-processing.ts
+++ b/apps/desktop/src/utils/image-processing.ts
@@ -144,6 +144,17 @@ export async function processAvatarFromBlob(
 }
 
 /**
+ * Process a Node icon from a cropped Blob.
+ * Resizes to 128x128 (single size — no small variant needed).
+ */
+export async function processNodeIconFromBlob(
+  blob: Blob
+): Promise<Uint8Array> {
+  const file = new File([blob], "node-icon.png", { type: blob.type || "image/png" });
+  return resizeImage(file, 128, 128);
+}
+
+/**
  * Generate a thumbnail for an image attachment.
  * Returns the thumbnail as Uint8Array.
  */

--- a/apps/desktop/src/utils/message-batcher.ts
+++ b/apps/desktop/src/utils/message-batcher.ts
@@ -6,15 +6,26 @@ import type { TransportMessage } from "@nodes/transport";
  * 
  * This prevents Gun's rapid-fire .map().on() callbacks from causing
  * thousands of individual React state updates per second.
+ *
+ * Includes a safety bound: if pending messages exceed MAX_PENDING_PER_CHANNEL,
+ * a fallback setTimeout flush fires to prevent unbounded growth during
+ * system sleep when RAF callbacks are paused.
  */
+const MAX_PENDING_PER_CHANNEL = 500;
+
 export function createMessageBatcher(
   addMessage: (channelId: string, message: TransportMessage) => void
 ) {
   const pending = new Map<string, TransportMessage[]>();
   let rafId: number | null = null;
+  let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
   const flush = () => {
     rafId = null;
+    if (fallbackTimer !== null) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = null;
+    }
     
     // Process all pending messages
     for (const [channelId, messages] of pending) {
@@ -34,11 +45,26 @@ export function createMessageBatcher(
       if (!pending.has(channelId)) {
         pending.set(channelId, []);
       }
+      const msgs = pending.get(channelId)!;
+
+      // Safety bound: if too many messages accumulated (e.g. during sleep),
+      // force an immediate flush before adding more.
+      if (msgs.length >= MAX_PENDING_PER_CHANNEL) {
+        flush();
+        if (!pending.has(channelId)) {
+          pending.set(channelId, []);
+        }
+      }
+
       pending.get(channelId)!.push(message);
 
       // Schedule flush if not already scheduled
       if (rafId === null) {
         rafId = requestAnimationFrame(flush);
+        // Fallback: if RAF doesn't fire within 2s (e.g. tab hidden), use setTimeout
+        if (fallbackTimer === null) {
+          fallbackTimer = setTimeout(flush, 2_000);
+        }
       }
     },
 
@@ -49,6 +75,10 @@ export function createMessageBatcher(
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
         rafId = null;
+      }
+      if (fallbackTimer !== null) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
       }
       pending.clear();
     },

--- a/packages/transport-gun/src/connection-monitor.ts
+++ b/packages/transport-gun/src/connection-monitor.ts
@@ -68,6 +68,29 @@ export class GunConnectionMonitor implements IConnectionMonitor {
   }
 
   /**
+   * Pause monitoring (e.g. when app goes to background / system sleeps).
+   * Clears the interval but keeps `started` true so `resume()` can restart it.
+   */
+  pause(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+
+  /**
+   * Resume monitoring after a pause. Does an immediate connection check
+   * and restarts the periodic ping.
+   */
+  resume(): void {
+    if (!this.started || this.pingTimer) return;
+    this.checkConnection();
+    this.pingTimer = setInterval(() => {
+      this.checkConnection();
+    }, PING_INTERVAL);
+  }
+
+  /**
    * Get current connection state.
    */
   getState(): ConnectionState {

--- a/packages/transport-gun/src/gun-instance.ts
+++ b/packages/transport-gun/src/gun-instance.ts
@@ -4,40 +4,35 @@ import "gun/sea";
 type GunInstance = ReturnType<typeof Gun>;
 type GunUser = ReturnType<GunInstance["user"]>;
 
-// Local relay for development (run: node scripts/gun-relay.mjs)
-const LOCAL_RELAY = "http://localhost:8765/gun";
-
-// Staging relay - set VITE_GUN_RELAY_URL env var to your deployed relay
-const STAGING_RELAY = import.meta.env.VITE_GUN_RELAY_URL as string | undefined;
-
-// Public relays - these change frequently, local relay is most reliable
-const PUBLIC_PEERS = [
-  "https://gun-manhattan.herokuapp.com/gun",
-  "https://gun-us.herokuapp.com/gun",
+const PRODUCTION_RELAYS = [
+  'wss://relay.nodes.services/gun',
+  'wss://relay2.nodes.services/gun',
 ];
 
-/**
- * Get the list of Gun relay peers based on environment.
- * Priority: VITE_GUN_RELAY_URL > local relay > public peers
- */
-function getDefaultPeers(): string[] {
-  const peers: string[] = [];
+const STAGING_RELAYS = [
+  import.meta.env.VITE_GUN_RELAY_URL as string,
+].filter(Boolean);
 
-  if (STAGING_RELAY) {
-    console.log("[Gun] Using relay:", STAGING_RELAY);
-    peers.push(STAGING_RELAY);
-    // When a relay is explicitly configured, use ONLY that relay.
-    // No public peer fallback — prevents cross-environment data contamination.
+const LOCAL_RELAY = 'http://localhost:8765/gun';
+
+function getDefaultPeers(): string[] {
+  if (STAGING_RELAYS.length > 0) {
+    // Production/staging: use configured relays + backup
+    const peers = [...STAGING_RELAYS];
+    // Add production backup relays if primary is a production relay
+    if (STAGING_RELAYS[0]?.includes('nodes.services')) {
+      for (const relay of PRODUCTION_RELAYS) {
+        if (!peers.includes(relay)) peers.push(relay);
+      }
+    }
     return peers;
   }
-
-  // No relay configured — dev fallback only
+  
   if (import.meta.env.DEV) {
-    peers.push(LOCAL_RELAY);
+    return [LOCAL_RELAY];
   }
-
-  peers.push(...PUBLIC_PEERS);
-  return peers;
+  
+  return PRODUCTION_RELAYS;
 }
 
 /**
@@ -62,6 +57,7 @@ console.warn = (...args: unknown[]) => {
  */
 
 let gunInstance: GunInstance | null = null;
+let activePeers: string[] = [];
 
 export class GunInstanceManager {
   /**
@@ -73,7 +69,7 @@ export class GunInstanceManager {
     if (gunInstance) return gunInstance;
 
     // Use provided peers, or get defaults based on environment
-    const activePeers = peers ?? getDefaultPeers();
+    activePeers = peers ?? getDefaultPeers();
     console.log("[Gun] Connecting to peers:", activePeers);
 
     gunInstance = Gun({
@@ -121,5 +117,12 @@ export class GunInstanceManager {
    */
   static reset(): void {
     gunInstance = null;
+  }
+
+  /**
+   * Get the peer URLs that Gun is connected to.
+   */
+  static getPeers(): string[] {
+    return activePeers;
   }
 }

--- a/packages/transport-gun/src/index.ts
+++ b/packages/transport-gun/src/index.ts
@@ -3,6 +3,10 @@ export { GunInstanceManager } from "./gun-instance";
 export { ProfileManager } from "./profile-manager";
 export type { ProfileData, ProfileWithVisibility } from "./profile-manager";
 
+// Relay health monitoring
+export { RelayHealthMonitor } from "./relay-health";
+export type { RelayStatus } from "./relay-health";
+
 // Transport implementations
 export { GunMessageTransport, generateMessageId } from "./message-transport";
 export { GunPresenceTransport } from "./presence-transport";
@@ -13,6 +17,7 @@ export { LocalFileTransport } from "./file-transport";
 export { IPFSService, getCachedDownload, setCachedDownload } from "./ipfs-service";
 export { IPFSFileTransport, configureFileTransport } from "./ipfs-file-transport";
 export { AvatarManager, avatarManager, configureAvatarManager } from "./avatar-manager";
+export { nodeIconManager, configureNodeIconManager } from "./node-icon-manager";
 export { IPFSPeerAdvertiser, getIPFSPeerAdvertiser } from "./ipfs-peer-advertiser";
 
 // Node management

--- a/packages/transport-gun/src/node-icon-manager.ts
+++ b/packages/transport-gun/src/node-icon-manager.ts
@@ -1,0 +1,252 @@
+import { IPFSService } from "./ipfs-service";
+
+/**
+ * NodeIconManager handles upload, caching, and retrieval of Node icons.
+ *
+ * Mirrors the AvatarManager pattern:
+ * - LRU memory cache with object URLs
+ * - In-flight request deduplication
+ * - Negative cache to prevent retry loops
+ * - Multi-gateway fetch fallback chain
+ * - Dual-pin on upload (Helia + staging server)
+ *
+ * Node icon CIDs are stored in the shared Gun graph at:
+ *   gun.get("nodes").get(nodeId).put({ icon: cidString })
+ * (handled by node-manager.ts updateNode)
+ */
+
+// Configuration - shared from avatar-manager's configure call
+let ipfsApiUrl: string | undefined;
+let ipfsGatewayUrl: string | undefined;
+let serverPinFetch: typeof fetch | undefined;
+
+const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
+
+export function configureNodeIconManager(config: {
+  ipfsApiUrl?: string;
+  ipfsGatewayUrl?: string;
+  serverPinFetch?: typeof fetch;
+}) {
+  ipfsApiUrl = config.ipfsApiUrl;
+  ipfsGatewayUrl = config.ipfsGatewayUrl;
+  serverPinFetch = config.serverPinFetch;
+}
+
+const ICON_CACHE_MAX = 100;
+const FAILURE_CACHE_TTL = 60000;
+const GATEWAY_TIMEOUT = 5000;
+const P2P_TIMEOUT = 10000;
+const PUBLIC_GATEWAY_TIMEOUT = 8000;
+
+interface CachedIcon {
+  objectUrl: string;
+  cid: string;
+}
+
+class NodeIconManager {
+  private cache = new Map<string, CachedIcon>();
+  private inFlight = new Map<string, Promise<string | null>>();
+  private failedCache = new Map<string, number>();
+
+  /**
+   * Pin image data to the staging IPFS node.
+   */
+  private async pinToServer(imageData: Uint8Array): Promise<string | null> {
+    if (!ipfsApiUrl) return null;
+
+    const fetchFn = serverPinFetch || fetch;
+    const boundary = "----NodesBoundary" + Date.now();
+    const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="node-icon.png"\r\nContent-Type: image/png\r\n\r\n`;
+    const footer = `\r\n--${boundary}--\r\n`;
+
+    const headerBytes = new TextEncoder().encode(header);
+    const footerBytes = new TextEncoder().encode(footer);
+
+    const body = new Uint8Array(headerBytes.length + imageData.length + footerBytes.length);
+    body.set(headerBytes, 0);
+    body.set(imageData, headerBytes.length);
+    body.set(footerBytes, headerBytes.length + imageData.length);
+
+    const res = await fetchFn(`${ipfsApiUrl}/api/v0/add?pin=true`, {
+      method: "POST",
+      headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+      body: body,
+    });
+
+    if (!res.ok) throw new Error(`IPFS pin failed: ${res.statusText}`);
+    const data = await res.json();
+    return data.Hash;
+  }
+
+  /**
+   * Upload a Node icon to IPFS (dual-pin) and return the CID + object URL.
+   * Caller is responsible for storing the CID via updateNode({ icon: cid }).
+   */
+  async uploadIcon(
+    nodeId: string,
+    iconBytes: Uint8Array
+  ): Promise<{ cid: string; objectUrl: string }> {
+    if (!IPFSService.isReady()) {
+      await IPFSService.init();
+    }
+
+    // 1. Pin to Helia (P2P)
+    const heliaCid = await IPFSService.upload(iconBytes);
+
+    // 2. Pin to staging server
+    let cid = heliaCid;
+    try {
+      const serverCid = await this.pinToServer(iconBytes);
+      if (serverCid) cid = serverCid;
+    } catch (err) {
+      console.warn("[NodeIcon] Server pin failed, using Helia CID:", err);
+    }
+
+    // 3. Invalidate old cache entry for this node
+    this.invalidate(nodeId);
+
+    // 4. Create object URL and pre-populate cache
+    const blob = new Blob([iconBytes.buffer as ArrayBuffer], { type: "image/png" });
+    const objectUrl = URL.createObjectURL(blob);
+    this.addToCache(nodeId, objectUrl, cid);
+
+    return { cid, objectUrl };
+  }
+
+  /**
+   * Get a Node's icon as an object URL.
+   * Checks cache → gateway → P2P → public gateways.
+   *
+   * @param nodeId - The Node's ID
+   * @param iconCid - The IPFS CID of the icon (from node.icon field)
+   * @returns Object URL for <img src>, or null
+   */
+  async getIcon(nodeId: string, iconCid: string): Promise<string | null> {
+    const cacheKey = nodeId;
+
+    // 1. Memory cache
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      if (cached.cid !== iconCid) {
+        // CID changed — invalidate and re-fetch
+        URL.revokeObjectURL(cached.objectUrl);
+        this.cache.delete(cacheKey);
+        this.failedCache.delete(cacheKey);
+      } else {
+        // LRU bump
+        this.cache.delete(cacheKey);
+        this.cache.set(cacheKey, cached);
+        return cached.objectUrl;
+      }
+    }
+
+    // 2. Negative cache
+    const failedAt = this.failedCache.get(cacheKey);
+    if (failedAt && Date.now() - failedAt < FAILURE_CACHE_TTL) {
+      return null;
+    }
+
+    // 3. Dedup in-flight
+    const existing = this.inFlight.get(cacheKey);
+    if (existing) return existing;
+
+    // 4. Fetch
+    const promise = this.fetchIcon(cacheKey, iconCid);
+    this.inFlight.set(cacheKey, promise);
+
+    try {
+      const result = await promise;
+      if (!result) this.failedCache.set(cacheKey, Date.now());
+      return result;
+    } finally {
+      this.inFlight.delete(cacheKey);
+    }
+  }
+
+  private async fetchIcon(cacheKey: string, cid: string): Promise<string | null> {
+    // 1. Staging gateway
+    if (ipfsGatewayUrl) {
+      try {
+        const fetchFn = serverPinFetch || fetch;
+        const response = await fetchFn(`${ipfsGatewayUrl}/ipfs/${cid}`, {
+          signal: AbortSignal.timeout(GATEWAY_TIMEOUT),
+        });
+        if (response.ok) {
+          const blob = await response.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          this.addToCache(cacheKey, objectUrl, cid);
+          return objectUrl;
+        }
+      } catch { /* next */ }
+    }
+
+    // 2. Helia P2P (skip on Tauri)
+    if (!isTauri) {
+      try {
+        if (!IPFSService.isReady()) await IPFSService.init();
+        const data = await IPFSService.download(cid, P2P_TIMEOUT);
+        const blob = new Blob([data.buffer as ArrayBuffer], { type: "image/png" });
+        const objectUrl = URL.createObjectURL(blob);
+        this.addToCache(cacheKey, objectUrl, cid);
+        return objectUrl;
+      } catch { /* next */ }
+    }
+
+    // 3. Public gateways
+    const publicGateways = [
+      `https://ipfs.io/ipfs/${cid}`,
+      `https://dweb.link/ipfs/${cid}`,
+      `https://w3s.link/ipfs/${cid}`,
+    ];
+
+    for (const url of publicGateways) {
+      try {
+        const fetchFn = serverPinFetch || fetch;
+        const response = await fetchFn(url, {
+          signal: AbortSignal.timeout(PUBLIC_GATEWAY_TIMEOUT),
+        });
+        if (response.ok) {
+          const blob = await response.blob();
+          const objectUrl = URL.createObjectURL(blob);
+          this.addToCache(cacheKey, objectUrl, cid);
+          return objectUrl;
+        }
+      } catch { /* next */ }
+    }
+
+    console.warn(`[NodeIcon] All fetch paths failed for ${cid}`);
+    return null;
+  }
+
+  private addToCache(key: string, objectUrl: string, cid: string): void {
+    if (this.cache.size >= ICON_CACHE_MAX) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest) {
+        const entry = this.cache.get(oldest);
+        if (entry) URL.revokeObjectURL(entry.objectUrl);
+        this.cache.delete(oldest);
+      }
+    }
+    this.cache.set(key, { objectUrl, cid });
+  }
+
+  invalidate(nodeId: string): void {
+    const entry = this.cache.get(nodeId);
+    if (entry) {
+      URL.revokeObjectURL(entry.objectUrl);
+      this.cache.delete(nodeId);
+    }
+    this.failedCache.delete(nodeId);
+  }
+
+  clearCache(): void {
+    for (const entry of this.cache.values()) {
+      URL.revokeObjectURL(entry.objectUrl);
+    }
+    this.cache.clear();
+    this.inFlight.clear();
+    this.failedCache.clear();
+  }
+}
+
+export const nodeIconManager = new NodeIconManager();

--- a/packages/transport-gun/src/node-manager.ts
+++ b/packages/transport-gun/src/node-manager.ts
@@ -177,10 +177,12 @@ export class NodeManager {
   subscribeToNodeMeta(
     nodeId: string,
     onDeleted: () => void,
-    onThemeChange?: (theme: import("@nodes/core").NodesTheme | null) => void
+    onThemeChange?: (theme: import("@nodes/core").NodesTheme | null) => void,
+    onIconChange?: (icon: string | null) => void
   ): () => void {
     const gun = GunInstanceManager.get();
     let lastThemeJson: string | undefined;
+    let lastIcon: string | undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ref = gun.get("nodes").get(nodeId).on((data: any) => {
       if (!data) return;
@@ -197,6 +199,11 @@ export class NodeManager {
           try { theme = JSON.parse(data.themeJson); } catch { /* ignore */ }
         }
         onThemeChange(theme);
+      }
+      // Detect icon changes for live update on other clients
+      if (onIconChange && data.icon !== lastIcon) {
+        lastIcon = data.icon;
+        onIconChange(data.icon || null);
       }
     });
     return () => ref.off();

--- a/packages/transport-gun/src/relay-health.ts
+++ b/packages/transport-gun/src/relay-health.ts
@@ -1,0 +1,142 @@
+export interface RelayStatus {
+  url: string;
+  connected: boolean;
+  latency: number | null; // ms, null if unreachable
+  lastChecked: number;
+}
+
+export class RelayHealthMonitor {
+  private relays: Map<string, RelayStatus> = new Map();
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private listeners: Set<(statuses: RelayStatus[]) => void> = new Set();
+  private customFetch: typeof fetch | undefined;
+
+  start(urls: string[], intervalMs: number = 30000, customFetch?: typeof fetch) {
+    this.customFetch = customFetch;
+    // Initialize all relays
+    for (const url of urls) {
+      this.relays.set(url, {
+        url,
+        connected: false,
+        latency: null,
+        lastChecked: 0,
+      });
+    }
+
+    // Ping immediately, then on interval
+    this.pingAll();
+    this.intervalId = setInterval(() => this.pingAll(), intervalMs);
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Pause health checks (e.g. app hidden / system sleep).
+   * Keeps relay state intact but stops pinging.
+   */
+  pause() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Resume health checks after a pause.
+   * Pings immediately then restarts the interval.
+   */
+  resume(intervalMs: number = 30000) {
+    if (this.intervalId) return; // already running
+    if (this.relays.size === 0) return; // never started
+    this.pingAll();
+    this.intervalId = setInterval(() => this.pingAll(), intervalMs);
+  }
+
+  getStatuses(): RelayStatus[] {
+    return Array.from(this.relays.values());
+  }
+
+  getConnectedCount(): number {
+    return Array.from(this.relays.values()).filter(r => r.connected).length;
+  }
+
+  onStatusChange(listener: (statuses: RelayStatus[]) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private async pingAll() {
+    const promises = Array.from(this.relays.keys()).map(url => this.ping(url));
+    await Promise.allSettled(promises);
+    this.notifyListeners();
+  }
+
+  private async ping(url: string) {
+    // Convert wss:// to https:// for health check
+    const httpUrl = url
+      .replace('wss://', 'https://')
+      .replace('ws://', 'http://')
+      .replace('/gun', '/health');
+
+    const start = Date.now();
+    try {
+      const fetchFn = this.customFetch || fetch;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+
+      // customFetch (Tauri native) can read the response normally.
+      // Browser fetch may hit CORS — use no-cors as fallback so we
+      // can at least detect reachability (opaque response = server up).
+      let connected = false;
+      let latency: number | null = null;
+
+      if (this.customFetch) {
+        const res = await fetchFn(httpUrl, { signal: controller.signal });
+        clearTimeout(timeout);
+        connected = res.ok;
+      } else {
+        // Try normal CORS fetch first
+        try {
+          const res = await fetchFn(httpUrl, { signal: controller.signal });
+          clearTimeout(timeout);
+          connected = res.ok;
+        } catch {
+          // CORS blocked — retry with no-cors (opaque response, but reachable = connected)
+          clearTimeout(timeout);
+          const controller2 = new AbortController();
+          const timeout2 = setTimeout(() => controller2.abort(), 5000);
+          await fetchFn(httpUrl, { signal: controller2.signal, mode: 'no-cors' });
+          clearTimeout(timeout2);
+          connected = true; // Didn't throw → server is reachable
+        }
+      }
+
+      latency = connected ? Date.now() - start : null;
+      this.relays.set(url, {
+        url,
+        connected,
+        latency,
+        lastChecked: Date.now(),
+      });
+    } catch {
+      this.relays.set(url, {
+        url,
+        connected: false,
+        latency: null,
+        lastChecked: Date.now(),
+      });
+    }
+  }
+
+  private notifyListeners() {
+    const statuses = this.getStatuses();
+    for (const listener of this.listeners) {
+      listener(statuses);
+    }
+  }
+}


### PR DESCRIPTION
Implements 5 issues from the v1.2.0 milestone:

- Closes #61: Caps-lock indicator for password and backup fields
- Closes #62: Node icon emoji rendering + custom image upload pipeline
- Closes #63: Desktop app idle/sleep-wake resilience
- Closes #65: Client-side data persistence (IndexedDB caching layer)
- Closes #68: Persist user voice settings across app restarts

Additional infrastructure:
- Multi-relay health monitoring (RelayHealthMonitor with pause/resume, CORS-aware no-cors fallback for browser context)
- Relay store + NetworkSettings UI + RelayStatusIndicator
- NodeIconManager (LRU + multi-gateway fetch + dual-pin upload)
- Real-time node icon propagation via subscribeToNodeMeta
- useAppVisibility hook (visibilitychange + heartbeat sleep detection)
- Polling pauses (channel/member/presence) when app hidden
- Bounded message batcher (force-flush at 500 + 2s setTimeout fallback)
- Splash screen polish